### PR TITLE
Optimize animations for motion preferences

### DIFF
--- a/src/lib/components/recipe-card/RecipeCard.svelte
+++ b/src/lib/components/recipe-card/RecipeCard.svelte
@@ -300,21 +300,27 @@
 		pointer-events: none;
 	}
 
-	.gradient-animate {
-		position: absolute;
-		inset: 0;
-		background: linear-gradient(
-			90deg,
-			rgba(255, 255, 255, 0.05) 0%,
-			rgba(255, 255, 255, 0.1) 25%,
-			rgba(255, 255, 255, 0.15) 50%,
-			rgba(255, 255, 255, 0.1) 75%,
-			rgba(255, 255, 255, 0.05) 100%
-		);
-		background-size: 200% 100%;
-		animation: gradient-shift 1.5s ease-in-out infinite;
-		will-change: background-position;
-	}
+       .gradient-animate {
+               position: absolute;
+               inset: 0;
+               background: linear-gradient(
+                       90deg,
+                       rgba(255, 255, 255, 0.05) 0%,
+                       rgba(255, 255, 255, 0.1) 25%,
+                       rgba(255, 255, 255, 0.15) 50%,
+                       rgba(255, 255, 255, 0.1) 75%,
+                       rgba(255, 255, 255, 0.05) 100%
+               );
+               background-size: 200% 100%;
+               animation: gradient-shift 1.5s ease-in-out infinite;
+               will-change: background-position;
+       }
+
+       @media (prefers-reduced-motion: reduce) {
+               .gradient-animate {
+                       animation: none;
+               }
+       }
 
 	.skeleton .image-container {
 		position: relative;

--- a/src/lib/components/recipe-grid/RecipeGrid.svelte
+++ b/src/lib/components/recipe-grid/RecipeGrid.svelte
@@ -59,16 +59,16 @@
 	})
 </script>
 
-<div in:fly={{ y: 50, duration: 300, delay: 300 }} out:fly={{ y: 50, duration: 300 }}>
+<div>
 	{#if recipes.length === 0}
 		<div class="empty-state">
 			<p>{emptyMessage}</p>
 		</div>
 	{:else}
-		<div class="recipe-grid">
-			{#each recipes as recipe (recipe.id)}
-				<RecipeCard {recipe} />
-			{/each}
+                <div class="recipe-grid">
+                        {#each recipes as recipe, i (recipe.id)}
+                                <RecipeCard {recipe} in:fly={{ y: 50, duration: 300, delay: i * 50 }} />
+                        {/each}
 
 			{#if isLoading}
 				{#each Array(18) as _}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -87,8 +87,8 @@
 		}
 	})
 
-	async function handleFlip(target: 'header' | 'homepage') {
-		if (!_flip) return
+       async function handleFlip(target: 'header' | 'homepage') {
+               if (!_flip || searchBarPosition === target) return
 
 		flipState = _flip.getState('.header-searchbar, .homepage-searchbar')
 
@@ -166,8 +166,7 @@
 		display: var(--header-display, block);
 	}
 
-	div {
-		position: relative;
-		will-change: transform;
-	}
+       div {
+               position: relative;
+       }
 </style>


### PR DESCRIPTION
## Summary
- disable skeleton animation when user prefers reduced motion
- stagger recipe card fly transitions
- avoid redundant GSAP Flip animations
- remove global will-change styling

## Testing
- `pnpm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684944b3dc3c8321bae1a32db692139b