### PR TITLE
Add collection rename and delete menu

### DIFF
--- a/src/lib/components/collection-card/CollectionCard.svelte
+++ b/src/lib/components/collection-card/CollectionCard.svelte
@@ -1,18 +1,111 @@
 <script lang="ts">
+	import Dropdown from '../dropdown/Dropdown.svelte'
+	import Popup from '../popup/Popup.svelte'
+	import Input from '../input/Input.svelte'
+	import Button from '../button/Button.svelte'
+	import { safeFetch } from '$lib/utils/fetch'
+	import MoreVertical from 'lucide-svelte/icons/more-vertical'
+
 	let { name, count = 0 }: { name: string; count?: number } = $props()
+
+	let menuOpen = $state(false)
+	let renameOpen = $state(false)
+	let deleteOpen = $state(false)
+	let newName = $state(name)
+
+	const handleRename = async () => {
+		const result = await safeFetch<{ success: true }>()('/api/collections/rename', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ oldName: name, newName })
+		})
+
+		if (result.isOk()) {
+			renameOpen = false
+			location.reload()
+		}
+	}
+
+	const handleDelete = async () => {
+		const result = await safeFetch<{ success: true }>()('/api/collections/delete', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ name })
+		})
+
+		if (result.isOk()) {
+			location.reload()
+		}
+	}
 </script>
 
-<a href={`/collection/${name}`} class="collection-card card">
-	<div class="collection-content">
-		<h3 class="collection-name">{name}</h3>
-		<div class="collection-count">{count} {count === 1 ? 'recipe' : 'recipes'}</div>
-	</div>
-</a>
+<div class="collection-card card">
+	{#if name !== 'All Recipes'}
+		<div class="menu-container">
+			<button class="menu-btn" onclick={() => (menuOpen = !menuOpen)} aria-label="Collection menu">
+				<MoreVertical size={16} />
+			</button>
+			<Dropdown bind:isOpen={menuOpen}>
+				<button
+					class="dropdown-item"
+					onclick={() => {
+						menuOpen = false
+						renameOpen = true
+					}}
+				>
+					Rename
+				</button>
+				<button
+					class="dropdown-item delete"
+					onclick={() => {
+						menuOpen = false
+						deleteOpen = true
+					}}
+				>
+					Delete
+				</button>
+			</Dropdown>
+		</div>
+	{/if}
+
+	<a href={`/collection/${name}`} class="collection-link">
+		<div class="collection-content">
+			<h3 class="collection-name">{name}</h3>
+			<div class="collection-count">{count} {count === 1 ? 'recipe' : 'recipes'}</div>
+		</div>
+	</a>
+
+	<Popup
+		isOpen={renameOpen}
+		onClose={() => (renameOpen = false)}
+		title="Rename Collection"
+		width="300px"
+	>
+		<Input bind:value={newName} actionButton={{ text: 'Save', onClick: handleRename }}>
+			<input type="text" placeholder="New name" bind:value={newName} />
+		</Input>
+	</Popup>
+
+	<Popup
+		isOpen={deleteOpen}
+		onClose={() => (deleteOpen = false)}
+		title="Delete Collection"
+		width="300px"
+	>
+		<div class="delete-content">
+			<p>Are you sure you want to delete "{name}"?</p>
+			<div class="delete-actions">
+				<Button color="primary" onclick={handleDelete}>Delete</Button>
+				<Button variant="border" onclick={() => (deleteOpen = false)}>Cancel</Button>
+			</div>
+		</div>
+	</Popup>
+</div>
 
 <style lang="scss">
 	.collection-card {
-		display: block;
-		
+		position: relative;
+		background: var(--color-neutral);
 		height: 100%;
 		width: 100%;
 
@@ -54,5 +147,56 @@
 	.collection-count {
 		color: var(--color-neutral-light);
 		font-size: var(--font-size-sm);
+	}
+
+	.menu-container {
+		position: absolute;
+		top: var(--spacing-sm);
+		right: var(--spacing-sm);
+	}
+
+	.menu-btn {
+		background: none;
+		border: none;
+		color: var(--color-neutral-light);
+		padding: var(--spacing-xs);
+		border-radius: var(--border-radius-sm);
+		cursor: pointer;
+		transition: background-color var(--transition-fast) var(--ease-in-out);
+
+		&:hover {
+			background-color: var(--color-hover);
+			color: var(--color-primary);
+		}
+	}
+
+	.dropdown-item {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: var(--spacing-sm) var(--spacing-md);
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--color-white);
+
+		&:hover {
+			background-color: var(--color-hover);
+		}
+	}
+
+	.dropdown-item.delete {
+		color: var(--color-error);
+	}
+
+	.delete-content p {
+		margin-top: 0;
+	}
+
+	.delete-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--spacing-sm);
+		margin-top: var(--spacing-md);
 	}
 </style>

--- a/src/lib/components/collection-card/CollectionCard.svelte
+++ b/src/lib/components/collection-card/CollectionCard.svelte
@@ -5,6 +5,7 @@
 	import Button from '../button/Button.svelte'
 	import { safeFetch } from '$lib/utils/fetch'
 	import MoreVertical from 'lucide-svelte/icons/more-vertical'
+	import { invalidateAll } from '$app/navigation'
 
 	let { name, count = 0 }: { name: string; count?: number } = $props()
 
@@ -22,7 +23,7 @@
 
 		if (result.isOk()) {
 			renameOpen = false
-			location.reload()
+			invalidateAll()
 		}
 	}
 
@@ -34,7 +35,7 @@
 		})
 
 		if (result.isOk()) {
-			location.reload()
+			invalidateAll()
 		}
 	}
 </script>
@@ -45,6 +46,7 @@
 			<button class="menu-btn" onclick={() => (menuOpen = !menuOpen)} aria-label="Collection menu">
 				<MoreVertical size={16} />
 			</button>
+			
 			<Dropdown bind:isOpen={menuOpen}>
 				<button
 					class="dropdown-item"
@@ -74,33 +76,33 @@
 			<div class="collection-count">{count} {count === 1 ? 'recipe' : 'recipes'}</div>
 		</div>
 	</a>
-
-	<Popup
-		isOpen={renameOpen}
-		onClose={() => (renameOpen = false)}
-		title="Rename Collection"
-		width="300px"
-	>
-		<Input bind:value={newName} actionButton={{ text: 'Save', onClick: handleRename }}>
-			<input type="text" placeholder="New name" bind:value={newName} />
-		</Input>
-	</Popup>
-
-	<Popup
-		isOpen={deleteOpen}
-		onClose={() => (deleteOpen = false)}
-		title="Delete Collection"
-		width="300px"
-	>
-		<div class="delete-content">
-			<p>Are you sure you want to delete "{name}"?</p>
-			<div class="delete-actions">
-				<Button color="primary" onclick={handleDelete}>Delete</Button>
-				<Button variant="border" onclick={() => (deleteOpen = false)}>Cancel</Button>
-			</div>
-		</div>
-	</Popup>
 </div>
+
+<Popup
+	isOpen={renameOpen}
+	onClose={() => (renameOpen = false)}
+	title="Rename Collection"
+	width="300px"
+>
+	<Input bind:value={newName} actionButton={{ text: 'Save', onClick: handleRename }}>
+		<input type="text" placeholder="New name" bind:value={newName} />
+	</Input>
+</Popup>
+
+<Popup
+	isOpen={deleteOpen}
+	onClose={() => (deleteOpen = false)}
+	title="Delete Collection"
+	width="300px"
+>
+	<div class="delete-content">
+		<p>Are you sure you want to delete "{name}"?</p>
+		<div class="delete-actions">
+			<Button color="primary" onclick={handleDelete}>Delete</Button>
+			<Button variant="border" onclick={() => (deleteOpen = false)}>Cancel</Button>
+		</div>
+	</div>
+</Popup>
 
 <style lang="scss">
 	.collection-card {
@@ -114,7 +116,6 @@
 			box-shadow var(--transition-fast) var(--ease-out);
 
 		&:hover {
-			transform: translateY(calc(var(--spacing-xs) * -1));
 			box-shadow: var(--shadow-lg);
 		}
 	}

--- a/src/lib/server/db/save.ts
+++ b/src/lib/server/db/save.ts
@@ -8,143 +8,167 @@ import type { DetailedRecipe } from './recipe'
  * Check if a recipe is saved by a user
  */
 export async function isRecipeSaved(recipeId: string, userId: string) {
-  const bookmarks = await db
-    .select()
-    .from(recipeBookmark)
-    .where(
-      and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId))
-    )
-  return bookmarks.length > 0
+	const bookmarks = await db
+		.select()
+		.from(recipeBookmark)
+		.where(and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId)))
+	return bookmarks.length > 0
 }
 
 /**
  * Toggle the saved status of a recipe for a user
  */
 export async function toggleRecipeSave(recipeId: string, userId: string, collectionName?: string) {
-  const existingSave = await isRecipeSaved(recipeId, userId)
+	const existingSave = await isRecipeSaved(recipeId, userId)
 
-  if (existingSave) {
-    await db.delete(recipeBookmark).where(
-      and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId))
-    )
-    return false
-  } else {
-    await db.insert(recipeBookmark).values({
-      userId,
-      recipeId,
-      collectionName
-    })
-    return true
-  }
+	if (existingSave) {
+		await db
+			.delete(recipeBookmark)
+			.where(and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId)))
+		return false
+	} else {
+		await db.insert(recipeBookmark).values({
+			userId,
+			recipeId,
+			collectionName
+		})
+		return true
+	}
 }
 
 /**
  * Remove a save from a recipe for a user
  */
 export async function removeRecipeSave(recipeId: string, userId: string) {
-  await db.delete(recipeBookmark).where(
-    and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId))
-  )
+	await db
+		.delete(recipeBookmark)
+		.where(and(eq(recipeBookmark.recipeId, recipeId), eq(recipeBookmark.userId, userId)))
 }
 
 /**
  * Get all recipes saved by a user
  */
 export async function getSavedRecipesByUser(userId: string) {
-  const bookmarks = await db
-    .select({
-      recipeId: recipeBookmark.recipeId,
-      collectionName: recipeBookmark.collectionName
-    })
-    .from(recipeBookmark)
-    .where(eq(recipeBookmark.userId, userId))
+	const bookmarks = await db
+		.select({
+			recipeId: recipeBookmark.recipeId,
+			collectionName: recipeBookmark.collectionName
+		})
+		.from(recipeBookmark)
+		.where(eq(recipeBookmark.userId, userId))
 
-  return bookmarks.map(bookmark => ({
-    recipeId: bookmark.recipeId,
-    collectionName: bookmark.collectionName
-  }))
+	return bookmarks.map((bookmark) => ({
+		recipeId: bookmark.recipeId,
+		collectionName: bookmark.collectionName
+	}))
 }
 
 /**
  * Get all collections for a user with their recipe counts
  */
 export async function getCollections(userId: string): Promise<{ name: string; count: number }[]> {
-  // Get all collections for the user
-  const collections = await db
-    .select()
-    .from(collection)
-    .where(eq(collection.userId, userId))
-    .orderBy(collection.createdAt)
+	// Get all collections for the user
+	const collections = await db
+		.select()
+		.from(collection)
+		.where(eq(collection.userId, userId))
+		.orderBy(collection.createdAt)
 
-  // Get recipe counts for each collection
-  const collectionCounts = await db
-    .select({
-      collectionName: recipeBookmark.collectionName,
-      count: sql<number>`count(*)`
-    })
-    .from(recipeBookmark)
-    .where(eq(recipeBookmark.userId, userId))
-    .groupBy(recipeBookmark.collectionName)
+	// Get recipe counts for each collection
+	const collectionCounts = await db
+		.select({
+			collectionName: recipeBookmark.collectionName,
+			count: sql<number>`count(*)`
+		})
+		.from(recipeBookmark)
+		.where(eq(recipeBookmark.userId, userId))
+		.groupBy(recipeBookmark.collectionName)
 
-  // Get total count of all saved recipes
-  const totalCount = await db
-    .select({
-      count: sql<number>`count(*)`
-    })
-    .from(recipeBookmark)
-    .where(eq(recipeBookmark.userId, userId))
-    .then(result => result[0]?.count || 0)
+	// Get total count of all saved recipes
+	const totalCount = await db
+		.select({
+			count: sql<number>`count(*)`
+		})
+		.from(recipeBookmark)
+		.where(eq(recipeBookmark.userId, userId))
+		.then((result) => result[0]?.count || 0)
 
-  return [
-    { name: 'All Recipes', count: totalCount },
-    ...collections.map(c => ({
-      name: c.name,
-      count: collectionCounts.find(cc => cc.collectionName === c.name)?.count || 0
-    }))
-  ]
+	return [
+		{ name: 'All Recipes', count: totalCount },
+		...collections.map((c) => ({
+			name: c.name,
+			count: collectionCounts.find((cc) => cc.collectionName === c.name)?.count || 0
+		}))
+	]
 }
 
 /**
  * Create a new collection for a user
  */
 export async function createCollection(userId: string, name: string) {
-  const newCollection = await db
-    .insert(collection)
-    .values({
-      userId,
-      name
-    })
-    .returning()
+	const newCollection = await db
+		.insert(collection)
+		.values({
+			userId,
+			name
+		})
+		.returning()
 
-  return newCollection[0]
+	return newCollection[0]
 }
 
 /**
  * Get all recipes in a collection
  */
 export async function getCollection(userId: string, collectionName: string) {
-  const bookmarks = await db
-    .select({
-      recipeId: recipeBookmark.recipeId
-    })
-    .from(recipeBookmark)
-    .where(
-      collectionName === 'All Recipes'
-        ? eq(recipeBookmark.userId, userId)
-        : and(
-            eq(recipeBookmark.userId, userId),
-            eq(recipeBookmark.collectionName, collectionName)
-          )
-    )
+	const bookmarks = await db
+		.select({
+			recipeId: recipeBookmark.recipeId
+		})
+		.from(recipeBookmark)
+		.where(
+			collectionName === 'All Recipes'
+				? eq(recipeBookmark.userId, userId)
+				: and(eq(recipeBookmark.userId, userId), eq(recipeBookmark.collectionName, collectionName))
+		)
 
-  const recipeIds = bookmarks.map(bookmark => bookmark.recipeId)
-  
-  if (recipeIds.length === 0) {
-    return []
-  }
+	const recipeIds = bookmarks.map((bookmark) => bookmark.recipeId)
 
-  return getRecipes({
-    recipeIds,
-    detailed: true
-  })
+	if (recipeIds.length === 0) {
+		return []
+	}
+
+	return getRecipes({
+		recipeIds,
+		detailed: true
+	})
+}
+
+/**
+ * Rename a collection
+ */
+export async function renameCollection(userId: string, oldName: string, newName: string) {
+	await db.transaction(async (tx) => {
+		await tx
+			.update(collection)
+			.set({ name: newName })
+			.where(and(eq(collection.userId, userId), eq(collection.name, oldName)))
+
+		await tx
+			.update(recipeBookmark)
+			.set({ collectionName: newName })
+			.where(and(eq(recipeBookmark.userId, userId), eq(recipeBookmark.collectionName, oldName)))
+	})
+}
+
+/**
+ * Delete a collection
+ */
+export async function deleteCollection(userId: string, name: string) {
+	const deleted = await db
+		.delete(collection)
+		.where(and(eq(collection.userId, userId), eq(collection.name, name)))
+		.returning()
+
+	return deleted.length > 0
 }

--- a/src/routes/api/collections/delete/+server.ts
+++ b/src/routes/api/collections/delete/+server.ts
@@ -1,0 +1,23 @@
+import { error, json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+import { deleteCollection } from '$lib/server/db/save'
+import * as v from 'valibot'
+
+const deleteSchema = v.object({
+	name: v.string()
+})
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) error(401, { message: 'Unauthorized' })
+
+	const data = await request.json()
+	const input = v.parse(deleteSchema, data)
+
+	try {
+		const success = await deleteCollection(locals.user.id, input.name)
+		if (!success) error(404, { message: 'Collection not found' })
+		return json({ success: true })
+	} catch (err) {
+		throw error(500, 'Failed to delete collection')
+	}
+}

--- a/src/routes/api/collections/delete/+server.ts
+++ b/src/routes/api/collections/delete/+server.ts
@@ -13,11 +13,8 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const data = await request.json()
 	const input = v.parse(deleteSchema, data)
 
-	try {
-		const success = await deleteCollection(locals.user.id, input.name)
-		if (!success) error(404, { message: 'Collection not found' })
-		return json({ success: true })
-	} catch (err) {
-		throw error(500, 'Failed to delete collection')
-	}
+
+	const success = await deleteCollection(locals.user.id, input.name)
+	if (!success) error(404, { message: 'Collection not found' })
+	return json({ success: true })
 }

--- a/src/routes/api/collections/rename/+server.ts
+++ b/src/routes/api/collections/rename/+server.ts
@@ -14,10 +14,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const data = await request.json()
 	const input = v.parse(renameSchema, data)
 
-	try {
-		await renameCollection(locals.user.id, input.oldName, input.newName)
-		return json({ success: true })
-	} catch (err) {
-		throw error(500, 'Failed to rename collection')
-	}
+	await renameCollection(locals.user.id, input.oldName, input.newName)
+	return json({ success: true })
 }

--- a/src/routes/api/collections/rename/+server.ts
+++ b/src/routes/api/collections/rename/+server.ts
@@ -1,0 +1,23 @@
+import { error, json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+import { renameCollection } from '$lib/server/db/save'
+import * as v from 'valibot'
+
+const renameSchema = v.object({
+	oldName: v.string(),
+	newName: v.string()
+})
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+	if (!locals.user) error(401, { message: 'Unauthorized' })
+
+	const data = await request.json()
+	const input = v.parse(renameSchema, data)
+
+	try {
+		await renameCollection(locals.user.id, input.oldName, input.newName)
+		return json({ success: true })
+	} catch (err) {
+		throw error(500, 'Failed to rename collection')
+	}
+}


### PR DESCRIPTION
## Summary
- add database helpers to rename and delete collections
- expose API routes for renaming and deleting
- update CollectionCard with menu button for rename/delete actions

## Testing
- `pnpm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68518b4669088321bfd5adc3a1195c8f