### PR TITLE
Add recipe menu for collection

### DIFF
--- a/src/lib/components/recipe-card/RecipeCard.svelte
+++ b/src/lib/components/recipe-card/RecipeCard.svelte
@@ -1,32 +1,66 @@
 <script lang="ts">
-	import Utensils from 'lucide-svelte/icons/utensils'
-	import LikeButton from '$lib/components/like-button/LikeButton.svelte'
-	import Pill from '$lib/components/pill/Pill.svelte'
-	import { navigating } from '$app/state'
-	import type { DetailedRecipe } from '$lib/server/db/recipe'
+        import Utensils from 'lucide-svelte/icons/utensils'
+        import LikeButton from '$lib/components/like-button/LikeButton.svelte'
+        import Dropdown from '$lib/components/dropdown/Dropdown.svelte'
+        import Popup from '$lib/components/popup/Popup.svelte'
+        import MoreVertical from 'lucide-svelte/icons/more-vertical'
+        import { safeFetch } from '$lib/utils/fetch'
+        import { invalidateAll } from '$app/navigation'
+        import Pill from '$lib/components/pill/Pill.svelte'
+        import { navigating } from '$app/state'
+        import type { DetailedRecipe } from '$lib/server/db/recipe'
 
-	let {
-		recipe,
-		loading = false,
-		size = 'large'
-	}: {
-		recipe?: DetailedRecipe
-		loading?: boolean
-		size?: 'large' | 'small'
-	} = $props()
+        let {
+                recipe,
+                loading = false,
+                size = 'large',
+                menu = false,
+                collections = [],
+                currentCollection
+        }: {
+                recipe?: DetailedRecipe
+                loading?: boolean
+                size?: 'large' | 'small'
+                menu?: boolean
+                collections?: string[]
+                currentCollection?: string
+        } = $props()
 
-	let isNavigating = $state(false)
+        let isNavigating = $state(false)
+        let menuOpen = $state(false)
+        let moveOpen = $state(false)
 
 	const handleClick = (event: MouseEvent) => {
 		if (!recipe) return
 		isNavigating = true
 	}
 
-	$effect(() => {
-		if (isNavigating && !navigating) {
-			isNavigating = false
-		}
-	})
+        $effect(() => {
+                if (isNavigating && !navigating) {
+                        isNavigating = false
+                }
+        })
+
+        const handleDelete = async () => {
+                if (!recipe) return
+                await safeFetch<{ saved: boolean }>()('/api/recipes/save', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ id: recipe.id })
+                })
+                invalidateAll()
+        }
+
+        const handleMove = async (collectionName?: string) => {
+                if (!recipe) return
+                await safeFetch<{ success: true }>()('/api/recipes/move', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ id: recipe.id, collectionName })
+                })
+                moveOpen = false
+                invalidateAll()
+        }
 </script>
 
 <a
@@ -47,12 +81,21 @@
 				<Utensils size={32} strokeWidth={1.5} />
 			</div>
 		{/if}
-		<div class="action-buttons">
-			{#if recipe}
-				<LikeButton count={recipe.likes} />
-			{/if}
-		</div>
-	</div>
+                <div class="action-buttons">
+                        {#if recipe}
+                                <LikeButton count={recipe.likes} />
+                                {#if menu}
+                                        <button class="menu-btn" on:click={() => (menuOpen = !menuOpen)} aria-label="Recipe menu">
+                                                <MoreVertical size={16} />
+                                        </button>
+                                        <Dropdown bind:isOpen={menuOpen}>
+                                                <button class="dropdown-item" on:click={() => { menuOpen = false; moveOpen = true }}>Move</button>
+                                                <button class="dropdown-item delete" on:click={() => { menuOpen = false; handleDelete() }}>Delete</button>
+                                        </Dropdown>
+                                {/if}
+                        {/if}
+                </div>
+        </div>
 	{#if loading}
 		<div class="avatar">
 			<div class="gradient-animate"></div>
@@ -109,12 +152,24 @@
 		</div>
 	</div>
 
-	{#if isNavigating}
-		<div class="spinner-overlay">
-			<div class="spinner"></div>
-		</div>
-	{/if}
+        {#if isNavigating}
+                <div class="spinner-overlay">
+                        <div class="spinner"></div>
+                </div>
+        {/if}
 </a>
+
+{#if menu}
+        <Popup isOpen={moveOpen} onClose={() => (moveOpen = false)} title="Move Recipe" width="300px">
+                <div class="collections-list">
+                        {#each collections.filter(c => c !== currentCollection) as collection}
+                                <div class="collection-item" on:click={() => handleMove(collection)}>
+                                        <div class="collection-item-name">{collection}</div>
+                                </div>
+                        {/each}
+                </div>
+        </Popup>
+{/if}
 
 <style lang="scss">
 	.recipe-card {
@@ -454,14 +509,69 @@
 		z-index: 10;
 	}
 
-	.spinner {
-		width: 48px;
-		height: 48px;
-		border: 4px solid rgba(0, 0, 0, 0.1);
-		border-top: 4px solid var(--color-primary, #4f46e5);
-		border-radius: 50%;
-		animation: spin 1s linear infinite;
-	}
+        .spinner {
+                width: 48px;
+                height: 48px;
+                border: 4px solid rgba(0, 0, 0, 0.1);
+                border-top: 4px solid var(--color-primary, #4f46e5);
+                border-radius: 50%;
+                animation: spin 1s linear infinite;
+        }
+
+        .menu-btn {
+                background: none;
+                border: none;
+                color: var(--color-neutral-light);
+                padding: var(--spacing-xs);
+                border-radius: var(--border-radius-sm);
+                cursor: pointer;
+                transition: background-color var(--transition-fast) var(--ease-in-out);
+
+                &:hover {
+                        background-color: var(--color-hover);
+                        color: var(--color-primary);
+                }
+        }
+
+        .dropdown-item {
+                display: block;
+                width: 100%;
+                text-align: left;
+                padding: var(--spacing-sm) var(--spacing-md);
+                background: none;
+                border: none;
+                cursor: pointer;
+                color: var(--color-white);
+
+                &:hover {
+                        background-color: var(--color-hover);
+                }
+        }
+
+        .dropdown-item.delete {
+                color: var(--color-error);
+        }
+
+        .collections-list {
+                display: flex;
+                flex-direction: column;
+                gap: var(--spacing-sm);
+                margin-top: var(--spacing-md);
+                margin-bottom: var(--spacing-md);
+        }
+
+        .collection-item {
+                display: flex;
+                align-items: center;
+                padding: var(--spacing-sm);
+                border-radius: var(--border-radius-md);
+                transition: background var(--transition-fast) var(--ease-in-out);
+                cursor: pointer;
+
+                &:hover {
+                        background: var(--color-neutral);
+                }
+        }
 
 	@keyframes spin {
 		0% {

--- a/src/lib/pages/collection/Collection.svelte
+++ b/src/lib/pages/collection/Collection.svelte
@@ -1,12 +1,62 @@
 <script lang="ts">
-       import CardGrid from '$lib/components/card-grid/CardGrid.svelte'
-       import RecipeCard from '$lib/components/recipe-card/RecipeCard.svelte'
-       import type { DetailedRecipe } from '$lib/server/db/recipe'
-       import { fly } from 'svelte/transition'
-       import ArrowLeftIcon from 'lucide-svelte/icons/arrow-left'
+	import CardGrid from '$lib/components/card-grid/CardGrid.svelte'
+	import RecipeCard from '$lib/components/recipe-card/RecipeCard.svelte'
+	import Popup from '$lib/components/popup/Popup.svelte'
+	import type { DetailedRecipe } from '$lib/server/db/recipe'
+	import { fly } from 'svelte/transition'
+	import ArrowLeftIcon from 'lucide-svelte/icons/arrow-left'
+	import { safeFetch } from '$lib/utils/fetch'
+	import { invalidateAll } from '$app/navigation'
 
-       let { name, recipes, collections = [] }:
-               { name: string; recipes: DetailedRecipe[]; collections?: string[] } = $props()
+	let {
+		name,
+		recipes,
+		collections = []
+	}: { name: string; recipes: DetailedRecipe[]; collections?: string[] } = $props()
+
+	let moveOpen = $state(false)
+	let selectedRecipeId: string | null = null
+
+	const handleDelete = async (recipeId: string) => {
+		await safeFetch<{ saved: boolean }>()('/api/recipes/save', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ id: recipeId })
+		})
+		invalidateAll()
+	}
+
+	const handleMove = async (recipeId: string, collectionName?: string) => {
+		await safeFetch<{ success: true }>()('/api/recipes/move', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ id: recipeId, collectionName })
+		})
+		moveOpen = false
+		selectedRecipeId = null
+		invalidateAll()
+	}
+
+	const openMovePopup = (recipeId: string) => {
+		selectedRecipeId = recipeId
+		moveOpen = true
+	}
+
+	const getMenuOptions = (recipeId: string) => {
+		const options: { [key: string]: () => void } = {}
+
+		if (name !== 'All Recipes') {
+			options['Move'] = () => {
+				openMovePopup(recipeId)
+			}
+		}
+
+		options['Remove'] = () => {
+			handleDelete(recipeId)
+		}
+
+		return options
+	}
 </script>
 
 <div in:fly={{ x: -50, duration: 300, delay: 500 }} out:fly={{ x: -50, duration: 300 }}>
@@ -17,12 +67,22 @@
 
 	<h1>{name}</h1>
 
-       <CardGrid items={recipes} useAnimation={false} emptyMessage="No recipes in this collection.">
-               {#snippet item(recipe)}
-                       <RecipeCard menu {recipe} {collections} currentCollection={name} />
-               {/snippet}
-       </CardGrid>
+	<CardGrid items={recipes} useAnimation={false} emptyMessage="No recipes in this collection.">
+		{#snippet item(recipe)}
+			<RecipeCard menu={{ options: getMenuOptions(recipe.id) }} {recipe} />
+		{/snippet}
+	</CardGrid>
 </div>
+
+<Popup isOpen={moveOpen} onClose={() => (moveOpen = false)} title="Move Recipe" width="300px">
+	<div class="collections-list">
+		{#each collections.filter((c) => c !== name && c !== 'All Recipes') as collection}
+			<button class="collection-item" onclick={() => selectedRecipeId && handleMove(selectedRecipeId, collection)}>
+				<div class="collection-item-name">{collection}</div>
+			</button>
+		{/each}
+	</div>
+</Popup>
 
 <style lang="scss">
 	.back-button {
@@ -37,5 +97,31 @@
 		margin-bottom: var(--spacing-md);
 		font-size: var(--font-size-sm);
 		transition: color var(--transition-fast) var(--ease-in-out);
+	}
+
+	.collections-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--spacing-sm);
+		margin-top: var(--spacing-md);
+		margin-bottom: var(--spacing-md);
+	}
+
+	.collection-item {
+		display: flex;
+		align-items: center;
+		padding: var(--spacing-sm);
+		border-radius: var(--border-radius-md);
+		transition: background var(--transition-fast) var(--ease-in-out);
+		cursor: pointer;
+		background: none;
+		border: none;
+		color: var(--color-white);
+		width: 100%;
+		text-align: left;
+
+		&:hover {
+			background: var(--color-neutral);
+		}
 	}
 </style>

--- a/src/lib/pages/collection/Collection.svelte
+++ b/src/lib/pages/collection/Collection.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import RecipeGrid from '$lib/components/recipe-grid/RecipeGrid.svelte'
-	import type { DetailedRecipe } from '$lib/server/db/recipe'
-	import { fly } from 'svelte/transition'
-	import ArrowLeftIcon from 'lucide-svelte/icons/arrow-left'
+       import CardGrid from '$lib/components/card-grid/CardGrid.svelte'
+       import RecipeCard from '$lib/components/recipe-card/RecipeCard.svelte'
+       import type { DetailedRecipe } from '$lib/server/db/recipe'
+       import { fly } from 'svelte/transition'
+       import ArrowLeftIcon from 'lucide-svelte/icons/arrow-left'
 
-	let { name, recipes }: { name: string; recipes: DetailedRecipe[] } = $props()
+       let { name, recipes, collections = [] }:
+               { name: string; recipes: DetailedRecipe[]; collections?: string[] } = $props()
 </script>
 
 <div in:fly={{ x: -50, duration: 300, delay: 500 }} out:fly={{ x: -50, duration: 300 }}>
@@ -15,7 +17,11 @@
 
 	<h1>{name}</h1>
 
-	<RecipeGrid {recipes} useAnimation={false} />
+       <CardGrid items={recipes} useAnimation={false} emptyMessage="No recipes in this collection.">
+               {#snippet item(recipe)}
+                       <RecipeCard menu {recipe} {collections} currentCollection={name} />
+               {/snippet}
+       </CardGrid>
 </div>
 
 <style lang="scss">

--- a/src/lib/server/db/save.ts
+++ b/src/lib/server/db/save.ts
@@ -170,5 +170,24 @@ export async function deleteCollection(userId: string, name: string) {
 		.where(and(eq(collection.userId, userId), eq(collection.name, name)))
 		.returning()
 
-	return deleted.length > 0
+        return deleted.length > 0
+}
+
+/**
+ * Move a saved recipe to a different collection
+ */
+export async function moveRecipeSave(
+        userId: string,
+        recipeId: string,
+        collectionName?: string
+) {
+        await db
+                .update(recipeBookmark)
+                .set({ collectionName })
+                .where(
+                        and(
+                                eq(recipeBookmark.userId, userId),
+                                eq(recipeBookmark.recipeId, recipeId)
+                        )
+                )
 }

--- a/src/routes/(pages)/collection/[name]/+page.server.ts
+++ b/src/routes/(pages)/collection/[name]/+page.server.ts
@@ -1,14 +1,16 @@
-import { error } from "@sveltejs/kit"
-import type { PageServerLoad } from "./$types"
-import { getCollection } from "$lib/server/db/save"
+import { error } from '@sveltejs/kit'
+import type { PageServerLoad } from './$types'
+import { getCollection, getCollections } from '$lib/server/db/save'
 
 export const load: PageServerLoad = async ({ locals, params }) => {
   if (!locals.user) error(401, 'Unauthorized')
 
   const recipes = await getCollection(locals.user.id, params.name)
+  const collections = await getCollections(locals.user.id).then(cs => cs.map(c => c.name))
 
   return {
     recipes,
-    name: params.name
+    name: params.name,
+    collections
   }
 }

--- a/src/routes/(pages)/collection/[name]/+page.svelte
+++ b/src/routes/(pages)/collection/[name]/+page.svelte
@@ -4,4 +4,4 @@
 	let { data } = $props()
 </script>
 
-<Collection name={data.name} recipes={data.recipes} />
+<Collection name={data.name} recipes={data.recipes} collections={data.collections} />

--- a/src/routes/api/recipes/move/+server.ts
+++ b/src/routes/api/recipes/move/+server.ts
@@ -1,0 +1,23 @@
+import { error, json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+import { moveRecipeSave, isRecipeSaved } from '$lib/server/db/save'
+import * as v from 'valibot'
+
+const moveSchema = v.object({
+  id: v.string(),
+  collectionName: v.optional(v.string())
+})
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+  if (!locals.user) error(401, { message: 'Unauthorized' })
+
+  const data = await request.json()
+  const input = v.parse(moveSchema, data)
+
+  const exists = await isRecipeSaved(input.id, locals.user.id)
+  if (!exists) error(404, { message: 'Recipe not saved' })
+
+  await moveRecipeSave(locals.user.id, input.id, input.collectionName)
+
+  return json({ success: true })
+}


### PR DESCRIPTION
## Summary
- add `moveRecipeSave` db util
- support moving saved recipes via `/api/recipes/move`
- show recipe card menu in collections with move and delete options

## Testing
- `pnpm test` *(fails: ECONNREFUSED connect)*

------
https://chatgpt.com/codex/tasks/task_e_685197275ba08321bf867b1c2d1b448f