### PR TITLE
Add popular tags carousel

### DIFF
--- a/src/lib/components/tag-carousel/TagCarousel.svelte
+++ b/src/lib/components/tag-carousel/TagCarousel.svelte
@@ -1,55 +1,97 @@
 <script lang="ts">
-	import Pill from '../pill/Pill.svelte'
-	import { onMount } from 'svelte'
+        import Pill from '../pill/Pill.svelte'
+        import { onMount } from 'svelte'
 
-	export type Tag = string
+        export type Tag = string
 
-	let { tags = [], onTagClick = (tag: string) => {} } = $props()
+        let { tags = [], onTagClick = (tag: string) => {} } = $props()
 
-	// Duplicate list for seamless scrolling
-	let scrollTags: Tag[] = []
-	let container: HTMLDivElement
-	let track: HTMLDivElement
+        type ScrollTag = { name: string; color: string }
 
-	onMount(() => {
-		scrollTags = [...tags, ...tags]
-	})
+        let scrollTags: ScrollTag[] = []
+        let container: HTMLDivElement
+        let track: HTMLDivElement
+
+        const randomColor = () =>
+                `hsl(${Math.floor(Math.random() * 360)}, ${70 + Math.floor(Math.random() * 20)}%, ${50 + Math.floor(Math.random() * 10)}%)`
+
+        const setupTags = () => {
+                scrollTags = [...tags, ...tags].map((t) => ({ name: t, color: randomColor() }))
+        }
+
+        onMount(setupTags)
+
+        $: if (tags) setupTags()
 </script>
 
 <div class="carousel" bind:this={container}>
-	<div class="track" bind:this={track}>
-		{#each scrollTags as tag}
-			<button class="tag-item" on:click={() => onTagClick(tag)}>
-				<Pill text={tag} />
-			</button>
-		{/each}
-	</div>
+        <div class="track" bind:this={track}>
+                {#each scrollTags as tag}
+                        <button class="tag-item" on:click={() => onTagClick(tag.name)}>
+                                <Pill text={tag.name} color={tag.color} />
+                        </button>
+                {/each}
+        </div>
 </div>
 
 <style lang="scss">
-	.carousel {
-		overflow: hidden;
-		width: 100%;
-	}
+        .carousel {
+                overflow: hidden;
+                width: 100%;
+                margin: 0 auto;
+                display: flex;
+                justify-content: center;
+                position: relative;
+        }
 
-	.track {
-		display: flex;
-		gap: var(--spacing-md);
-		white-space: nowrap;
-		animation: scroll linear infinite 40s;
-	}
+        .carousel::before,
+        .carousel::after {
+                content: '';
+                position: absolute;
+                top: 0;
+                width: var(--spacing-2xl);
+                height: 100%;
+                pointer-events: none;
+                z-index: 1;
+        }
 
-	.carousel:hover .track {
-		animation-play-state: paused;
-	}
+        .carousel::before {
+                left: 0;
+                background: linear-gradient(to right, var(--color-background), transparent);
+        }
 
-	.tag-item {
-		background: none;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-		flex-shrink: 0;
-	}
+        .carousel::after {
+                right: 0;
+                background: linear-gradient(to left, var(--color-background), transparent);
+        }
+
+        .track {
+                display: flex;
+                gap: var(--spacing-lg);
+                white-space: nowrap;
+                animation: scroll linear infinite 30s;
+                align-items: center;
+        }
+
+        .carousel:hover .track {
+                animation-play-state: paused;
+        }
+
+        .tag-item {
+                background: none;
+                border: none;
+                padding: 0;
+                cursor: pointer;
+                flex-shrink: 0;
+        }
+
+        .tag-item :global(.pill) {
+                height: 32px;
+        }
+
+        .tag-item :global(.pill-text) {
+                font-size: var(--font-size-sm);
+        }
 
 	@keyframes scroll {
 		from {

--- a/src/lib/components/tag-carousel/TagCarousel.svelte
+++ b/src/lib/components/tag-carousel/TagCarousel.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+	import Pill from '../pill/Pill.svelte'
+	import { onMount } from 'svelte'
+
+	export type Tag = string
+
+	let { tags = [], onTagClick = (tag: string) => {} } = $props()
+
+	// Duplicate list for seamless scrolling
+	let scrollTags: Tag[] = []
+	let container: HTMLDivElement
+	let track: HTMLDivElement
+
+	onMount(() => {
+		scrollTags = [...tags, ...tags]
+	})
+</script>
+
+<div class="carousel" bind:this={container}>
+	<div class="track" bind:this={track}>
+		{#each scrollTags as tag}
+			<button class="tag-item" on:click={() => onTagClick(tag)}>
+				<Pill text={tag} />
+			</button>
+		{/each}
+	</div>
+</div>
+
+<style lang="scss">
+	.carousel {
+		overflow: hidden;
+		width: 100%;
+	}
+
+	.track {
+		display: flex;
+		gap: var(--spacing-md);
+		white-space: nowrap;
+		animation: scroll linear infinite 40s;
+	}
+
+	.carousel:hover .track {
+		animation-play-state: paused;
+	}
+
+	.tag-item {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	@keyframes scroll {
+		from {
+			transform: translateX(0);
+		}
+		to {
+			transform: translateX(-50%);
+		}
+	}
+</style>

--- a/src/lib/pages/home/Home.svelte
+++ b/src/lib/pages/home/Home.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import RecipeGrid from '$lib/components/recipe-grid/RecipeGrid.svelte'
 	import Pill from '$lib/components/pill/Pill.svelte'
+	import TagCarousel from '$lib/components/tag-carousel/TagCarousel.svelte'
 	import { onMount, type ComponentProps, type Snippet } from 'svelte'
 	import { setSlots } from '../../../routes/+layout.svelte'
 	import { writable } from 'svelte/store'
@@ -57,6 +58,7 @@
 	let flipState = $state<any>(null)
 	let searchBarPosition = $state<'header' | 'filters'>('header')
 	let searchValue = $state('')
+	let popularTags = $state<string[]>([])
 
 	onMount(() => {
 		checkMobile()
@@ -65,6 +67,11 @@
 		// Initialize selected values
 		selectedTags = initialTags.map((tag) => ({ label: tag, selected: true }))
 		selectedIngredients = initialIngredients
+
+		// Load popular tags for carousel
+		searchTags('').then((results) => {
+			popularTags = results.map((t) => t.name)
+		})
 
 		let observer: IntersectionObserver | null = null
 		let unsubscribe = sentinelNode.subscribe((node) => {
@@ -142,6 +149,13 @@
 	const removeTag = (tag: string) => {
 		selectedTags = selectedTags.filter((t) => t.label !== tag)
 		notifyFiltersChanged()
+	}
+
+	const addTag = (tag: string) => {
+		if (!selectedTags.some((t) => t.label === tag)) {
+			selectedTags = [...selectedTags, { label: tag, selected: true }]
+			notifyFiltersChanged()
+		}
 	}
 
 	const removeIngredient = (ingredient: string) => {
@@ -229,6 +243,10 @@
 
 {#snippet homepageHeader()}
 	<div class="large-header">Effortless food recipes, made by the community.</div>
+
+	{#if popularTags.length > 0}
+		<TagCarousel tags={popularTags} onTagClick={addTag} />
+	{/if}
 
 	<div bind:this={$sentinelNode} style="height: 60px;"></div>
 

--- a/src/routes/api/tags/+server.ts
+++ b/src/routes/api/tags/+server.ts
@@ -2,31 +2,32 @@ import { json } from '@sveltejs/kit'
 import { searchTags, getPopularTags } from '$lib/server/db/tags'
 
 export type TagSearchResponse = {
-  tags: Array<{
-    name: string
-    count: number
-  }>
-  query: string
+	tags: Array<{
+		name: string
+		count: number
+	}>
+	query: string
 }
 
 export const GET = async ({ url }) => {
-  const query = url.searchParams.get('q') || ''
-  const limit = 5
+	const query = url.searchParams.get('q') || ''
+	const limitParam = url.searchParams.get('limit')
+	const limit = limitParam ? parseInt(limitParam, 10) || 5 : 5
 
-  // If query is empty, get most popular tags
-  if (!query.trim()) {
-    const popularTags = await getPopularTags(limit)
-    return json({
-      tags: popularTags,
-      query: ''
-    } satisfies TagSearchResponse)
-  }
+	// If query is empty, get most popular tags
+	if (!query.trim()) {
+		const popularTags = await getPopularTags(limit)
+		return json({
+			tags: popularTags,
+			query: ''
+		} satisfies TagSearchResponse)
+	}
 
-  // Search for tags that match the query
-  const tagResults = await searchTags(query, limit)
+	// Search for tags that match the query
+	const tagResults = await searchTags(query, limit)
 
-  return json({
-    tags: tagResults,
-    query
-  } satisfies TagSearchResponse)
-} 
+	return json({
+		tags: tagResults,
+		query
+	} satisfies TagSearchResponse)
+}


### PR DESCRIPTION
## Summary
- fetch more tags via optional `limit` query parameter
- display popular tags in a new TagCarousel component
- show TagCarousel on the homepage and allow clicking tags to filter

## Testing
- `npm run lint` *(fails: Code style issues found)*
- `npm test` *(fails: tests timeout due to database connection)*

------
https://chatgpt.com/codex/tasks/task_e_6852cb67e96483219e55921c74d683d9