### PR TITLE
Update search behavior for mobile

### DIFF
--- a/src/lib/components/search/Search.svelte
+++ b/src/lib/components/search/Search.svelte
@@ -8,6 +8,7 @@
 		inputElement = $bindable(),
 		value = $bindable(''),
 		onInput = $bindable((newValue: string) => {}),
+		onConfirm = $bindable((value: string) => {}),
 		actionButton,
 		formName,
 		...inputProps
@@ -17,6 +18,7 @@
 		inputElement?: HTMLInputElement
 		value?: string
 		onInput?: (value: string) => void
+		onConfirm?: (value: string) => void
 		actionButton?: { text: string; onClick: () => void }
 		formName?: string
 	} & Omit<ComponentProps<typeof Input>, 'children' | 'value'> = $props()
@@ -24,6 +26,16 @@
 	const handleInput = (e: Event) => {
 		value = (e.target as HTMLInputElement).value
 		onInput(value)
+	}
+
+	const handleKeydown = (e: KeyboardEvent) => {
+		if (e.key === 'Enter') {
+			onConfirm(value)
+		}
+	}
+
+	const handleSearchEvent = () => {
+		onConfirm(value)
 	}
 </script>
 
@@ -50,9 +62,12 @@
 				{placeholder}
 				{value}
 				oninput={handleInput}
+				onkeydown={handleKeydown}
+				onsearch={handleSearchEvent}
 				aria-label="Search"
 				name={formName}
 				bind:this={inputElement}
+				enterkeyhint="search"
 			/>
 		</Input>
 	</div>

--- a/src/lib/components/search/Search.svelte
+++ b/src/lib/components/search/Search.svelte
@@ -28,14 +28,19 @@
 		onInput(value)
 	}
 
+	const confirmSearch = () => {
+		onConfirm(value)
+		inputElement?.blur()
+	}
+
 	const handleKeydown = (e: KeyboardEvent) => {
 		if (e.key === 'Enter') {
-			onConfirm(value)
+			confirmSearch()
 		}
 	}
 
 	const handleSearchEvent = () => {
-		onConfirm(value)
+		confirmSearch()
 	}
 </script>
 

--- a/src/lib/pages/home/Home.svelte
+++ b/src/lib/pages/home/Home.svelte
@@ -217,7 +217,12 @@
 			bind:value={searchValue}
 			onInput={(query) => {
 				searchValue = query
-				window.dispatchEvent(new CustomEvent('search', { detail: { query } }))
+				if (!isMobile) {
+					window.dispatchEvent(new CustomEvent('search', { detail: { query } }))
+				}
+			}}
+			onConfirm={() => {
+				window.dispatchEvent(new CustomEvent('search', { detail: { query: searchValue } }))
 			}}
 			{isLoading}
 			roundedCorners


### PR DESCRIPTION
## Summary
- trigger search on mobile only when user confirms
- expose `onConfirm` event in `Search` component for search input handling

## Testing
- `npx prettier -w src/lib/components/search/Search.svelte src/lib/pages/home/Home.svelte`

------
https://chatgpt.com/codex/tasks/task_e_6852fb990df4832188c87a532c321a69