### PR TITLE
Limit recipe instruction videos to 10s

### DIFF
--- a/src/lib/server/cloudinary.ts
+++ b/src/lib/server/cloudinary.ts
@@ -42,7 +42,7 @@ export const uploadMedia = async (
     options.transformation = {
       ...options.transformation,
       quality: 'auto',
-      duration: 30 // Limit videos to 30 seconds
+      duration: 10 // Limit videos to 10 seconds
     }
   }
 


### PR DESCRIPTION
## Summary
- enforce 10s duration cap when uploading instruction videos

## Testing
- `pre-commit` *(fails: command not run as per instructions)*

------
https://chatgpt.com/codex/tasks/task_e_685336513b10832186b8f3fb70f8ab32