### PR TITLE
Centralize fly transitions

### DIFF
--- a/src/lib/pages/collection/Collection.svelte
+++ b/src/lib/pages/collection/Collection.svelte
@@ -4,6 +4,7 @@
 	import Popup from '$lib/components/popup/Popup.svelte'
 	import type { DetailedRecipe } from '$lib/server/db/recipe'
 	import { fly } from 'svelte/transition'
+	import { FLY_LEFT_IN, FLY_LEFT_OUT } from '$lib/utils/transitions'
 	import ArrowLeftIcon from 'lucide-svelte/icons/arrow-left'
 	import { safeFetch } from '$lib/utils/fetch'
 	import { invalidateAll } from '$app/navigation'
@@ -59,7 +60,7 @@
 	}
 </script>
 
-<div in:fly={{ x: -50, duration: 300, delay: 500 }} out:fly={{ x: -50, duration: 300 }}>
+<div in:fly={FLY_LEFT_IN} out:fly={FLY_LEFT_OUT}>
 	<a class="back-button" href="/profile?tab=Saved recipes">
 		<ArrowLeftIcon size={18} />
 		<span>Back to saved recipes</span>
@@ -77,7 +78,10 @@
 <Popup isOpen={moveOpen} onClose={() => (moveOpen = false)} title="Move Recipe" width="300px">
 	<div class="collections-list">
 		{#each collections.filter((c) => c !== name && c !== 'All Recipes') as collection}
-			<button class="collection-item" onclick={() => selectedRecipeId && handleMove(selectedRecipeId, collection)}>
+			<button
+				class="collection-item"
+				onclick={() => selectedRecipeId && handleMove(selectedRecipeId, collection)}
+			>
 				<div class="collection-item-name">{collection}</div>
 			</button>
 		{/each}

--- a/src/lib/pages/new-recipe/NewRecipe.svelte
+++ b/src/lib/pages/new-recipe/NewRecipe.svelte
@@ -11,6 +11,7 @@
 	import Pill from '$lib/components/pill/Pill.svelte'
 	import FilterSelector from '$lib/components/filter-selector/FilterSelector.svelte'
 	import { fly } from 'svelte/transition'
+	import { NEW_RECIPE_STEP_IN, NEW_RECIPE_STEP_OUT } from '$lib/utils/transitions'
 
 	type T = $$Generic<{ name: string; custom: false }>
 	type Ingredient = T | { name: string; custom: true }
@@ -206,8 +207,8 @@
 		<div
 			class="step-content card"
 			class:hidden={currentStep !== 1}
-			in:fly={{ x: 200, delay: 200, duration: 200 }}
-			out:fly={{ x: -200, duration: 200 }}
+			in:fly={NEW_RECIPE_STEP_IN}
+			out:fly={NEW_RECIPE_STEP_OUT}
 		>
 			<h2>Basic Information</h2>
 			<MediaUpload name="image" type="image" previewAlt="Recipe preview" />
@@ -259,8 +260,8 @@
 		<div
 			class="step-content card"
 			class:hidden={currentStep !== 2}
-			in:fly={{ x: 200, delay: 200, duration: 200 }}
-			out:fly={{ x: -200, duration: 200 }}
+			in:fly={NEW_RECIPE_STEP_IN}
+			out:fly={NEW_RECIPE_STEP_OUT}
 		>
 			<h2>Ingredients & Servings</h2>
 			<div class="form-group">
@@ -322,8 +323,8 @@
 		<div
 			class="step-content card"
 			class:hidden={currentStep !== 3}
-			in:fly={{ x: 200, delay: 200, duration: 200 }}
-			out:fly={{ x: -200, duration: 200 }}
+			in:fly={NEW_RECIPE_STEP_IN}
+			out:fly={NEW_RECIPE_STEP_OUT}
 		>
 			<h2>Instructions</h2>
 			<div class="form-group">

--- a/src/lib/pages/profile/DesktopLayout.svelte
+++ b/src/lib/pages/profile/DesktopLayout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 	import { fly } from 'svelte/transition'
+	import { FLY_LEFT_IN, FLY_LEFT_OUT } from '$lib/utils/transitions'
 	import TabSelect from '$lib/components/tab-select/TabSelect.svelte'
 
 	let {
@@ -28,11 +29,7 @@
 	} = $props()
 </script>
 
-<div
-	class="profile-container"
-	in:fly={{ x: -50, duration: 300, delay: 500 }}
-	out:fly={{ x: -50, duration: 300 }}
->
+<div class="profile-container" in:fly={FLY_LEFT_IN} out:fly={FLY_LEFT_OUT}>
 	<div class="profile-header-row card">
 		<div class="profile-avatar-block">
 			{@render avatar()}

--- a/src/lib/pages/profile/MobileLayout.svelte
+++ b/src/lib/pages/profile/MobileLayout.svelte
@@ -5,6 +5,7 @@
 	import Bookmark from 'lucide-svelte/icons/bookmark'
 	import ArrowLeft from 'lucide-svelte/icons/arrow-left'
 	import { fly } from 'svelte/transition'
+	import { FLY_LEFT_IN, FLY_LEFT_OUT } from '$lib/utils/transitions'
 	import { goto } from '$app/navigation'
 
 	let {
@@ -37,11 +38,7 @@
 	}
 </script>
 
-<div
-	class="profile-view"
-	in:fly={{ x: -50, duration: 300, delay: 500 }}
-	out:fly={{ x: -50, duration: 300 }}
->
+<div class="profile-view" in:fly={FLY_LEFT_IN} out:fly={FLY_LEFT_OUT}>
 	<div class="profile-card card">
 		<div class="avatar-row">{@render avatar()}</div>
 		<div class="name-row">{@render name()}</div>
@@ -72,7 +69,11 @@
 		<div class="profile-detail-header">
 			<button class="back-btn" onclick={() => open()}><ArrowLeft size={20} /></button>
 			<span class="detail-title">
-				{view === 'Profile info' ? 'Profile' : view === 'Created recipes' ? 'Created recipes' : 'Saved recipes'}
+				{view === 'Profile info'
+					? 'Profile'
+					: view === 'Created recipes'
+						? 'Created recipes'
+						: 'Saved recipes'}
 			</span>
 		</div>
 

--- a/src/lib/pages/recipe/DesktopLayout.svelte
+++ b/src/lib/pages/recipe/DesktopLayout.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 	import { fly } from 'svelte/transition'
+	import {
+		FLY_LEFT_IN,
+		FLY_LEFT_IN_SHORT,
+		FLY_LEFT_OUT,
+		FLY_DOWN_IN,
+		FLY_DOWN_OUT
+	} from '$lib/utils/transitions'
 
 	let {
 		image,
@@ -27,22 +34,14 @@
 
 <div class="desktop-layout">
 	<div class="sidebar">
-		<div
-			class="action-buttons"
-			in:fly={{ x: -50, duration: 300, delay: 500 }}
-			out:fly={{ x: -50, duration: 300 }}
-		>
+		<div class="action-buttons" in:fly={FLY_LEFT_IN} out:fly={FLY_LEFT_OUT}>
 			{@render actionButtons()}
 		</div>
 	</div>
 
 	<div class="main-content">
 		<div class="content-grid">
-			<div
-				class="recipe-info"
-				in:fly={{ x: -50, duration: 300, delay: 300 }}
-				out:fly={{ x: -50, duration: 300 }}
-			>
+			<div class="recipe-info" in:fly={FLY_LEFT_IN_SHORT} out:fly={FLY_LEFT_OUT}>
 				<div class="tags-and-action-buttons">
 					<div class="tags">
 						{@render tags()}
@@ -58,22 +57,14 @@
 				</div>
 			</div>
 
-			<div
-				class="right-column"
-				in:fly={{ y: 50, duration: 300, delay: 300 }}
-				out:fly={{ x: -50, duration: 300 }}
-			>
+			<div class="right-column" in:fly={FLY_DOWN_IN} out:fly={FLY_LEFT_OUT}>
 				<div class="recipe-media">
 					{@render image()}
 				</div>
 				{@render instructions()}
 			</div>
 		</div>
-		<div
-			class="comments-section"
-			in:fly={{ y: 50, duration: 300, delay: 300 }}
-			out:fly={{ y: 50, duration: 300 }}
-		>
+		<div class="comments-section" in:fly={FLY_DOWN_IN} out:fly={FLY_DOWN_OUT}>
 			{@render comments()}
 		</div>
 	</div>

--- a/src/lib/utils/transitions.ts
+++ b/src/lib/utils/transitions.ts
@@ -1,0 +1,15 @@
+import type { FlyParams } from 'svelte/transition'
+
+export const FLY_LEFT_IN: FlyParams = { x: -50, duration: 300, delay: 500 }
+export const FLY_LEFT_IN_SHORT: FlyParams = { x: -50, duration: 300, delay: 300 }
+export const FLY_LEFT_OUT: FlyParams = { x: -50, duration: 300 }
+
+export const FLY_DOWN_IN: FlyParams = { y: 50, duration: 300, delay: 300 }
+export const FLY_DOWN_OUT: FlyParams = { y: 50, duration: 300 }
+
+export const NEW_RECIPE_STEP_IN: FlyParams = {
+	x: 200,
+	delay: 200,
+	duration: 200
+}
+export const NEW_RECIPE_STEP_OUT: FlyParams = { x: -200, duration: 200 }


### PR DESCRIPTION
## Summary
- add shared fly transitions
- use shared transitions across pages

## Testing
- `pnpm lint` *(fails: Code style issues found in 144 files)*
- `pnpm test` *(fails: recipe.test.ts connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685336f59b088321bd1b3a370a3256d9