### PR TITLE
Fix search query filtering

### DIFF
--- a/src/lib/server/db/recipe.ts
+++ b/src/lib/server/db/recipe.ts
@@ -219,7 +219,19 @@ export async function getRecipes(filters: RecipeFilter = {}): Promise<BasicRecip
     const limitedQuery = limit ? finalQuery.limit(limit) : finalQuery
 
     const results = await limitedQuery
-    return nullToUndefined(results)
+
+    const filteredResults = query.trim()
+      ? results.filter((recipe) => {
+          const searchTerms = query.toLowerCase().trim().split(/\s+/).filter(Boolean)
+          return searchTerms.every((term) =>
+            recipe.title.toLowerCase().includes(term) ||
+            recipe.tags.some((t) => t.toLowerCase().includes(term)) ||
+            recipe.ingredients.some((ing) => ing.name.toLowerCase().includes(term))
+          )
+        })
+      : results
+
+    return nullToUndefined(filteredResults)
   } else {
     // Basic query with limited fields
     const basicRecipeQuery = db
@@ -248,7 +260,18 @@ export async function getRecipes(filters: RecipeFilter = {}): Promise<BasicRecip
     const limitedQuery = limit ? finalQuery.limit(limit) : finalQuery
 
     const results = await limitedQuery
-    return nullToUndefined(results)
+
+    const filteredResults = query.trim()
+      ? results.filter((recipe) => {
+          const searchTerms = query.toLowerCase().trim().split(/\s+/).filter(Boolean)
+          return searchTerms.every((term) =>
+            recipe.title.toLowerCase().includes(term) ||
+            recipe.tags.some((t) => t.toLowerCase().includes(term))
+          )
+        })
+      : results
+
+    return nullToUndefined(filteredResults)
   }
 }
 


### PR DESCRIPTION
## Summary
- fix search endpoint to filter recipes that don't actually match the query
- move the search term filter into `getRecipes`

## Testing
- `pnpm exec tsc -p tsconfig.json --noEmit` *(fails: Module has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_68533788420c8321b6c7ddb932d7eccf