### PR TITLE
Align sort dropdown styling with other filters

### DIFF
--- a/src/lib/components/filter-select/OptionFilterSelect.svelte
+++ b/src/lib/components/filter-select/OptionFilterSelect.svelte
@@ -49,6 +49,7 @@
 </BaseFilterSelect>
 
 <style lang="scss">
+       @import '$lib/global.scss';
 	.arrow {
 		display: flex;
 		align-items: center;
@@ -60,13 +61,19 @@
 		}
 	}
 
-	.item {
-		padding: var(--spacing-xs) var(--spacing-sm);
+        .item {
+                padding: var(--spacing-xs) var(--spacing-sm);
 
-		&:hover {
-			background-color: var(--color-neutral);
-		}
-	}
+                &:hover {
+                        background-color: var(--color-neutral);
+                }
+
+                @include tablet {
+                        border: 1px solid var(--color-neutral);
+                        border-radius: var(--border-radius-xl);
+                        margin: var(--spacing-md) var(--spacing-sm);
+                }
+        }
 
 	.helper-text {
 		padding: var(--spacing-sm);


### PR DESCRIPTION
## Summary
- update sort dropdown item style to match other filters

## Testing
- `pre-commit` *(fails: missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856852e465c8321a64b6cb6180e09bd