### PR TITLE
Add recipe popup preview on homepage

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,7 +8,6 @@ declare global {
 		}
 		interface PageState {
 			recipeModal?: unknown
-			animateFrom?: { left: number; top: number; width: number; height: number }
 		}
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,7 @@ declare global {
 		}
 		interface PageState {
 			recipeModal?: unknown
+			animateFrom?: { left: number; top: number; width: number; height: number }
 		}
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -3,10 +3,13 @@
 declare global {
 	namespace App {
 		interface Locals {
-			user: import('$lib/server/auth').SessionValidationResult['user'];
-			session: import('$lib/server/auth').SessionValidationResult['session'];
+			user: import('$lib/server/auth').SessionValidationResult['user']
+			session: import('$lib/server/auth').SessionValidationResult['session']
+		}
+		interface PageState {
+			recipeModal?: unknown
 		}
 	}
 }
 
-export {};
+export {}

--- a/src/lib/components/popup/Popup.svelte
+++ b/src/lib/components/popup/Popup.svelte
@@ -4,13 +4,22 @@
 
 	let {
 		isOpen = $bindable(false),
-		title = $bindable(''),
-		showCloseButton = $bindable(true),
-		closeOnClickOutside = $bindable(true),
-		width = $bindable('400px'),
-		onClose = $bindable<(() => void) | undefined>(undefined),
-		children = $bindable<Snippet | undefined>(undefined),
-		headerActions = $bindable<Snippet | undefined>(undefined)
+		title,
+		showCloseButton = true,
+		closeOnClickOutside = true,
+		width = '400px',
+		onClose,
+		children,
+		headerActions
+	}: {
+		isOpen?: boolean
+		title?: string
+		showCloseButton?: boolean
+		closeOnClickOutside?: boolean
+		width?: string
+		onClose?: () => void
+		children?: Snippet
+		headerActions?: Snippet
 	} = $props()
 
 	const handleClose = () => {

--- a/src/lib/components/popup/Popup.svelte
+++ b/src/lib/components/popup/Popup.svelte
@@ -10,7 +10,8 @@
 		closeOnClickOutside = true,
 		width = '400px',
 		onClose,
-		children
+		children,
+		headerActions
 	}: {
 		isOpen?: boolean
 		title?: string
@@ -19,6 +20,7 @@
 		width?: string
 		onClose?: () => void
 		children?: Snippet
+		headerActions?: Snippet
 	} = $props()
 
 	let popupWrapper: HTMLDivElement | null = $state(null)
@@ -58,7 +60,7 @@
 						{/if}
 					</div>
 					<div class="popup-actions">
-						<slot name="header-actions" />
+						{@render headerActions?.()}
 						{#if showCloseButton}
 							<button class="popup-close" onclick={handleClose} aria-label="Close popup">
 								<svg

--- a/src/lib/components/popup/Popup.svelte
+++ b/src/lib/components/popup/Popup.svelte
@@ -2,6 +2,8 @@
 	import type { Snippet } from 'svelte'
 	import { fade, scale } from 'svelte/transition'
 	import { quintOut } from 'svelte/easing'
+	import gsap from 'gsap'
+	import { tick } from 'svelte'
 
 	let {
 		isOpen = $bindable(false),
@@ -11,7 +13,43 @@
 		width = '400px',
 		onClose,
 		children,
-		headerActions
+		openFrom = null,
+		containerEl = null
+		openFrom?: DOMRect | null
+		containerEl?: HTMLDivElement | null
+	$: containerEl = popupWrapper
+
+
+	async function animateOpen(rect: DOMRect) {
+		await tick()
+		if (!popupWrapper) return
+		const endRect = popupWrapper.getBoundingClientRect()
+
+		gsap.fromTo(
+			popupWrapper,
+			{
+				x: rect.left - endRect.left,
+				y: rect.top - endRect.top,
+				width: rect.width,
+				height: rect.height,
+				scale: 1
+			},
+			{
+				x: 0,
+				y: 0,
+				width: endRect.width,
+				height: endRect.height,
+				duration: 0.3,
+				ease: 'power1.inOut',
+				clearProps: 'width,height,transform'
+			}
+		)
+	}
+
+	$: if (isOpen && openFrom) {
+		animateOpen(openFrom)
+	}
+			transition:scale={openFrom ? null : { duration: 300, easing: quintOut, start: 0.95 }}
 	}: {
 		isOpen?: boolean
 		title?: string
@@ -91,6 +129,7 @@
 
 <style lang="scss">
 	@import '$lib/global.scss';
+		transform-origin: top left;
 	.popup-overlay {
 		position: fixed;
 		top: 0;

--- a/src/lib/components/popup/Popup.svelte
+++ b/src/lib/components/popup/Popup.svelte
@@ -2,7 +2,7 @@
 	import type { Snippet } from 'svelte'
 	import { fade } from 'svelte/transition'
 	import gsap from 'gsap'
-	import { tick } from 'svelte'
+	import { onMount, tick } from 'svelte'
 
 	let {
 		isOpen = $bindable(false),
@@ -17,6 +17,7 @@
 	} = $props()
 
 	let popupWrapper: HTMLDivElement | null = $state(null)
+	let showContent = $state(true)
 
 	// Animate opening: from card‐rect → final popup rect
 	async function animateOpen(rect: DOMRect) {
@@ -80,10 +81,14 @@
 		if (isOpen && openFrom) {
 			animateOpen(openFrom)
 		}
+		if (isOpen) {
+			showContent = true
+		}
 	})
 
 	// close handler: reverse‐animate then call onClose
 	const handleClose = async () => {
+		showContent = false
 		if (openFrom && popupWrapper) {
 			await animateClose(openFrom)
 		}
@@ -104,6 +109,7 @@
 </script>
 
 <svelte:document onmousedown={handleClickOutside} onkeydown={handleKeydown} />
+
 {#if isOpen}
 	<div class="popup-overlay" transition:fade={{ duration: openFrom ? 0 : 200 }}>
 		<div class="popup-container" bind:this={popupWrapper} style="max-width: {width};">
@@ -137,9 +143,11 @@
 					</div>
 				</div>
 			{/if}
-			<div class="popup-content">
-				{@render children?.()}
-			</div>
+			{#if showContent}
+				<div class="popup-content">
+					{@render children?.()}
+				</div>
+			{/if}
 		</div>
 	</div>
 {/if}
@@ -220,8 +228,9 @@
 
 	.popup-content {
 		padding: var(--spacing-lg);
-		overflow-y: auto;
+		overflow-y: scroll;
 		height: 100%;
+		scrollbar-width: thin;
 
 		@include mobile {
 			padding: var(--spacing-md);

--- a/src/lib/components/popup/Popup.svelte
+++ b/src/lib/components/popup/Popup.svelte
@@ -57,24 +57,27 @@
 							<h3 class="popup-title">{title}</h3>
 						{/if}
 					</div>
-					{#if showCloseButton}
-						<button class="popup-close" onclick={handleClose} aria-label="Close popup">
-							<svg
-								xmlns="http://www.w3.org/2000/svg"
-								width="20"
-								height="20"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-								stroke-linecap="round"
-								stroke-linejoin="round"
-							>
-								<line x1="18" y1="6" x2="6" y2="18" />
-								<line x1="6" y1="6" x2="18" y2="18" />
-							</svg>
-						</button>
-					{/if}
+					<div class="popup-actions">
+						<slot name="header-actions" />
+						{#if showCloseButton}
+							<button class="popup-close" onclick={handleClose} aria-label="Close popup">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+								>
+									<line x1="18" y1="6" x2="6" y2="18" />
+									<line x1="6" y1="6" x2="18" y2="18" />
+								</svg>
+							</button>
+						{/if}
+					</div>
 				</div>
 			{/if}
 			<div class="popup-content">
@@ -129,6 +132,12 @@
 		justify-content: space-between;
 		padding: var(--spacing-lg);
 		padding-bottom: 0;
+	}
+
+	.popup-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--spacing-sm);
 	}
 
 	.popup-title {

--- a/src/lib/components/recipe-card/RecipeCard.svelte
+++ b/src/lib/components/recipe-card/RecipeCard.svelte
@@ -13,7 +13,8 @@
 		recipe,
 		loading = false,
 		size = 'large',
-		menu
+		menu,
+		onRecipeClick
 	}: {
 		recipe?: DetailedRecipe
 		loading?: boolean
@@ -21,6 +22,7 @@
 		menu?: {
 			options: { [key: string]: () => void }
 		}
+		onRecipeClick?: (recipe: DetailedRecipe, event: MouseEvent) => Promise<void>
 	} = $props()
 
 	let isNavigating = $state(false)
@@ -37,6 +39,9 @@
 	const handleClick = (event: MouseEvent) => {
 		if (!recipe) return
 		isNavigating = true
+		onRecipeClick?.(recipe, event).then(() => {
+			isNavigating = false
+		})
 	}
 
 	$effect(() => {

--- a/src/lib/components/recipe-card/RecipeCard.svelte
+++ b/src/lib/components/recipe-card/RecipeCard.svelte
@@ -3,11 +3,10 @@
 	import Dropdown from '$lib/components/dropdown/Dropdown.svelte'
 	import MoreVertical from 'lucide-svelte/icons/more-vertical'
 	import Pill from '$lib/components/pill/Pill.svelte'
-	import RecipeMediaDisplay from '$lib/components/recipe-media/RecipeMediaDisplay.svelte'
 	import ProfilePic from '$lib/components/profile-pic/ProfilePic.svelte'
 	import RecipeImagePlaceholder from '$lib/components/recipe-image-placeholder/RecipeImagePlaceholder.svelte'
-	import { navigating } from '$app/state'
 	import type { DetailedRecipe } from '$lib/server/db/recipe'
+	import { afterNavigate } from '$app/navigation'
 
 	let {
 		recipe,
@@ -29,12 +28,6 @@
 	let menuOpen = $state(false)
 	let menuButton: HTMLButtonElement
 	let dropdownPosition = $state({ top: 0, left: 0 })
-	let showSlideshow = $state(false)
-	let hoverTimeout: ReturnType<typeof setTimeout> | null = null
-
-	const videoMedia = $derived(
-		recipe?.instructions.filter((i) => i.mediaType === 'video' && i.mediaUrl) ?? []
-	)
 
 	const handleClick = (event: MouseEvent) => {
 		if (!recipe) return
@@ -44,10 +37,8 @@
 		})
 	}
 
-	$effect(() => {
-		if (isNavigating && !navigating) {
-			isNavigating = false
-		}
+	afterNavigate(() => {
+		isNavigating = false
 	})
 
 	const updateDropdownPosition = () => {
@@ -69,19 +60,6 @@
 		}
 	}
 
-	function handleMouseEnter() {
-		if (videoMedia.length === 0) return
-		hoverTimeout = setTimeout(() => {
-			showSlideshow = true
-		}, 500)
-	}
-
-	function handleMouseLeave() {
-		if (hoverTimeout) clearTimeout(hoverTimeout)
-		hoverTimeout = null
-		showSlideshow = false
-	}
-
 	$effect(() => {
 		if (menuOpen) {
 			updateDropdownPosition()
@@ -96,19 +74,10 @@
 	class:small={size === 'small'}
 	aria-labelledby={recipe ? `recipe-title-${recipe.id}` : undefined}
 	onclick={handleClick}
-	onmouseenter={handleMouseEnter}
-	onmouseleave={handleMouseLeave}
 >
 	<div class="image-container" class:no-image={recipe && !recipe.imageUrl}>
 		{#if loading}
 			<div class="gradient-animate"></div>
-		{:else if showSlideshow && videoMedia.length > 0}
-			<RecipeMediaDisplay
-				mainImageUrl={recipe?.imageUrl}
-				media={videoMedia}
-				aspectRatio="auto"
-				autoplay={true}
-			/>
 		{:else if recipe?.imageUrl}
 			<img src={recipe.imageUrl} alt="" aria-hidden="true" loading="lazy" decoding="async" />
 		{:else}

--- a/src/lib/components/recipe-grid/RecipeGrid.svelte
+++ b/src/lib/components/recipe-grid/RecipeGrid.svelte
@@ -9,7 +9,8 @@
 		isLoading = false,
 		useAnimation = true,
 		loadMore,
-		size = 'large'
+		size = 'large',
+		onRecipeClick
 	}: {
 		recipes: NonNullable<ComponentProps<typeof RecipeCard>['recipe']>[]
 		emptyMessage?: string
@@ -17,6 +18,7 @@
 		loadMore?: () => Promise<void>
 		useAnimation?: boolean
 		size?: 'large' | 'small'
+		onRecipeClick?: (id: string, e: MouseEvent) => void
 	} = $props()
 
 	let loadMoreTrigger: HTMLElement
@@ -59,9 +61,9 @@
 <CardGrid items={renderedItems} {emptyMessage} {useAnimation} {size}>
 	{#snippet item(recipe)}
 		{#if recipe.loading}
-			<RecipeCard loading size={size} />
+			<RecipeCard loading {size} />
 		{:else}
-			<RecipeCard {size} {recipe} />
+			<RecipeCard {size} {recipe} on:click={(e) => onRecipeClick?.(recipe.id, e)} />
 		{/if}
 	{/snippet}
 </CardGrid>

--- a/src/lib/components/recipe-grid/RecipeGrid.svelte
+++ b/src/lib/components/recipe-grid/RecipeGrid.svelte
@@ -2,6 +2,7 @@
 	import RecipeCard from '$lib/components/recipe-card/RecipeCard.svelte'
 	import CardGrid from '$lib/components/card-grid/CardGrid.svelte'
 	import { onMount, type ComponentProps } from 'svelte'
+	import type { DetailedRecipe } from '$lib/server/db/recipe'
 
 	let {
 		recipes = [],
@@ -18,7 +19,7 @@
 		loadMore?: () => Promise<void>
 		useAnimation?: boolean
 		size?: 'large' | 'small'
-		onRecipeClick?: (id: string, e: MouseEvent) => void
+		onRecipeClick?: (recipe: DetailedRecipe, event: MouseEvent) => Promise<void>
 	} = $props()
 
 	let loadMoreTrigger: HTMLElement
@@ -63,7 +64,7 @@
 		{#if recipe.loading}
 			<RecipeCard loading {size} />
 		{:else}
-			<RecipeCard {size} {recipe} on:click={(e) => onRecipeClick?.(recipe.id, e)} />
+			<RecipeCard {size} {recipe} {onRecipeClick} />
 		{/if}
 	{/snippet}
 </CardGrid>

--- a/src/lib/components/recipe-media/RecipeMediaDisplay.svelte
+++ b/src/lib/components/recipe-media/RecipeMediaDisplay.svelte
@@ -9,17 +9,17 @@
 		mediaType?: 'image' | 'video'
 	}
 
-        let {
-                mainImageUrl,
-                media,
-                aspectRatio = '1/1',
-                autoplay = false
-        } = $props<{
-                mainImageUrl?: string
-                media: Media[]
-                aspectRatio?: string
-                autoplay?: boolean
-        }>()
+	let {
+		mainImageUrl,
+		media,
+		aspectRatio = '1/1',
+		autoplay = false
+	} = $props<{
+		mainImageUrl?: string
+		media: Media[]
+		aspectRatio?: string
+		autoplay?: boolean
+	}>()
 
 	// Video player and slideshow state
 	let videoPlayerVisible = $state(false)
@@ -49,16 +49,16 @@
 	])
 
 	// Check if we only have images (including main recipe image)
-        const hasOnlyImages = $derived(instructionMedia.every((media) => media.type === 'image'))
-        const hasVideos = $derived(instructionMedia.some((media) => media.type === 'video'))
+	const hasOnlyImages = $derived(instructionMedia.every((media) => media.type === 'image'))
+	const hasVideos = $derived(instructionMedia.some((media) => media.type === 'video'))
 
-        $effect(() => {
-                if (autoplay && hasVideos) {
-                        videoPlayerVisible = true
-                } else if (!autoplay) {
-                        videoPlayerVisible = false
-                }
-        })
+	$effect(() => {
+		if (autoplay && hasVideos) {
+			videoPlayerVisible = true
+		} else if (!autoplay) {
+			videoPlayerVisible = false
+		}
+	})
 
 	function toggleVideoPlayer() {
 		videoPlayerVisible = !videoPlayerVisible
@@ -133,11 +133,11 @@
 				<div class="slide">
 					<img src={instructionMedia[0].url} alt="Recipe" />
 				</div>
-                                {#if hasVideos && !autoplay}
-                                        <button class="play-button" onclick={toggleVideoPlayer}>
-                                                <svelte:component this={Play} size={28} color="white" />
-                                        </button>
-                                {/if}
+				{#if hasVideos && !autoplay}
+					<button class="play-button" onclick={toggleVideoPlayer}>
+						<svelte:component this={Play} size={28} color="white" />
+					</button>
+				{/if}
 			{/if}
 		</div>
 	{/if}

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -5,12 +5,18 @@
 	import { goto } from '$app/navigation'
 	import { page } from '$app/state'
 
-	export let data: any
-	export let isOpen = false
-	export let onClose: () => void = () => {}
-	export let animateFrom: DOMRect | null = null
+	let {
+		data = $bindable<any>(undefined),
+		isOpen = $bindable(false),
+		onClose = $bindable<(() => void)>(() => {}),
+		animateFrom = $bindable<{ left: number; top: number; width: number; height: number } | null>(null)
+	} = $props()
 
-	let popupEl: HTMLDivElement | null = null
+	// Convert plain object back to DOMRect for the Popup component
+	const domRect = $derived(() => {
+		if (!animateFrom) return null
+		return new DOMRect(animateFrom.left, animateFrom.top, animateFrom.width, animateFrom.height)
+	})
 
 	const openFullPage = (e: MouseEvent) => {
 		if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
@@ -19,7 +25,7 @@
 	}
 </script>
 
-<Popup {isOpen} {onClose} width="90vw" bind:containerEl={popupEl} openFrom={animateFrom}>
+<Popup {isOpen} {onClose} width="90vw" openFrom={domRect()}>
 	{#snippet headerActions()}
 		<button aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
 			<ExternalLink size={20} />

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import Popup from '../popup/Popup.svelte'
+	import ExternalLink from 'lucide-svelte/icons/external-link'
+	import RecipePage from '../../../routes/(pages)/recipe/[id]/+page.svelte'
+
+	export let data: any
+	export let isOpen = false
+	export let onClose: () => void = () => {}
+
+	const url = data ? `/recipe/${data.id}` : ''
+</script>
+
+<Popup {isOpen} {onClose} width="90vw">
+	{#if data}
+		<div class="fullscreen-link">
+			<a href={url} aria-label="Open full page"><ExternalLink size={20} /></a>
+		</div>
+		<RecipePage {data} />
+	{/if}
+</Popup>
+
+<style lang="scss">
+	.fullscreen-link {
+		position: absolute;
+		top: var(--spacing-sm);
+		right: var(--spacing-sm);
+		z-index: 1;
+	}
+</style>

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -3,6 +3,7 @@
 	import ExternalLink from 'lucide-svelte/icons/external-link'
 	import RecipePage from '../../../routes/(pages)/recipe/[id]/+page.svelte'
 	import { goto } from '$app/navigation'
+	import { page } from '$app/state'
 
 	export let data: any
 	export let isOpen = false
@@ -11,21 +12,18 @@
 
 	let popupEl: HTMLDivElement | null = null
 
-	const url = data ? `/recipe/${data.id}` : ''
-
 	const openFullPage = (e: MouseEvent) => {
-		if (!url) return
 		if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
 		e.preventDefault()
-		goto(url, { replaceState: true })
+		goto(window.location.href, { replaceState: false })
 	}
 </script>
 
 <Popup {isOpen} {onClose} width="90vw" bind:containerEl={popupEl} openFrom={animateFrom}>
 	{#snippet headerActions()}
-		<a href={url} aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
+		<button aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
 			<ExternalLink size={20} />
-		</a>
+		</button>
 	{/snippet}
 	<RecipePage {data} />
 </Popup>

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -19,14 +19,12 @@
 </script>
 
 <Popup {isOpen} {onClose} width="90vw">
-	{#if data}
-		<svelte:fragment slot="header-actions">
-			<a href={url} aria-label="Open full page" class="fullscreen-link" on:click={openFullPage}>
-				<ExternalLink size={20} />
-			</a>
-		</svelte:fragment>
-		<RecipePage {data} />
-	{/if}
+	{#snippet headerActions()}
+		<a href={url} aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
+			<ExternalLink size={20} />
+		</a>
+	{/snippet}
+	<RecipePage {data} />
 </Popup>
 
 <style lang="scss">

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -7,6 +7,9 @@
 	export let data: any
 	export let isOpen = false
 	export let onClose: () => void = () => {}
+	export let animateFrom: DOMRect | null = null
+
+	let popupEl: HTMLDivElement | null = null
 
 	const url = data ? `/recipe/${data.id}` : ''
 
@@ -18,7 +21,7 @@
 	}
 </script>
 
-<Popup {isOpen} {onClose} width="90vw">
+<Popup {isOpen} {onClose} width="90vw" bind:containerEl={popupEl} openFrom={animateFrom}>
 	{#snippet headerActions()}
 		<a href={url} aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
 			<ExternalLink size={20} />

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -2,28 +2,44 @@
 	import Popup from '../popup/Popup.svelte'
 	import ExternalLink from 'lucide-svelte/icons/external-link'
 	import RecipePage from '../../../routes/(pages)/recipe/[id]/+page.svelte'
+	import { goto } from '$app/navigation'
 
 	export let data: any
 	export let isOpen = false
 	export let onClose: () => void = () => {}
 
 	const url = data ? `/recipe/${data.id}` : ''
+
+	const openFullPage = (e: MouseEvent) => {
+		if (!url) return
+		if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
+		e.preventDefault()
+		goto(url, { replaceState: true })
+	}
 </script>
 
 <Popup {isOpen} {onClose} width="90vw">
 	{#if data}
-		<div class="fullscreen-link">
-			<a href={url} aria-label="Open full page"><ExternalLink size={20} /></a>
-		</div>
+		<svelte:fragment slot="header-actions">
+			<a href={url} aria-label="Open full page" class="fullscreen-link" on:click={openFullPage}>
+				<ExternalLink size={20} />
+			</a>
+		</svelte:fragment>
 		<RecipePage {data} />
 	{/if}
 </Popup>
 
 <style lang="scss">
 	.fullscreen-link {
-		position: absolute;
-		top: var(--spacing-sm);
-		right: var(--spacing-sm);
-		z-index: 1;
+		display: flex;
+		align-items: center;
+		padding: var(--spacing-xs);
+		border-radius: var(--border-radius-sm);
+		color: var(--color-neutral);
+
+		&:hover {
+			background: var(--color-hover);
+			color: var(--color-primary);
+		}
 	}
 </style>

--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -3,20 +3,12 @@
 	import ExternalLink from 'lucide-svelte/icons/external-link'
 	import RecipePage from '../../../routes/(pages)/recipe/[id]/+page.svelte'
 	import { goto } from '$app/navigation'
-	import { page } from '$app/state'
 
 	let {
 		data = $bindable<any>(undefined),
 		isOpen = $bindable(false),
-		onClose = $bindable<(() => void)>(() => {}),
-		animateFrom = $bindable<{ left: number; top: number; width: number; height: number } | null>(null)
+		onClose = $bindable<() => void>(() => {})
 	} = $props()
-
-	// Convert plain object back to DOMRect for the Popup component
-	const domRect = $derived(() => {
-		if (!animateFrom) return null
-		return new DOMRect(animateFrom.left, animateFrom.top, animateFrom.width, animateFrom.height)
-	})
 
 	const openFullPage = (e: MouseEvent) => {
 		if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
@@ -25,7 +17,7 @@
 	}
 </script>
 
-<Popup {isOpen} {onClose} width="90vw" openFrom={domRect()}>
+<Popup {isOpen} {onClose} width="90vw">
 	{#snippet headerActions()}
 		<button aria-label="Open full page" class="fullscreen-link" onclick={openFullPage}>
 			<ExternalLink size={20} />

--- a/src/lib/pages/home/Home.svelte
+++ b/src/lib/pages/home/Home.svelte
@@ -202,6 +202,10 @@
 		return ingredients.map((ingredient) => ingredient.name)
 	}
 
+	let popupFromRect: DOMRect | null = null
+
+		popupFromRect = (e.currentTarget as HTMLElement).getBoundingClientRect()
+		popupFromRect = null
 	let resolveRecipePopup: (value: void) => void
 
 	const openRecipePopup = async (recipe: DetailedRecipe, e: MouseEvent) => {
@@ -319,6 +323,7 @@
 							<Pill
 								text={`-${ingredient.label}`}
 								onRemove={() => removeIngredient(ingredient.label)}
+	animateFrom={popupFromRect}
 							/>
 						{/each}
 					</div>

--- a/src/lib/pages/home/Home.svelte
+++ b/src/lib/pages/home/Home.svelte
@@ -202,10 +202,7 @@
 		return ingredients.map((ingredient) => ingredient.name)
 	}
 
-	let popupFromRect: DOMRect | null = null
-
-		popupFromRect = (e.currentTarget as HTMLElement).getBoundingClientRect()
-		popupFromRect = null
+	
 	let resolveRecipePopup: (value: void) => void
 
 	const openRecipePopup = async (recipe: DetailedRecipe, e: MouseEvent) => {
@@ -213,11 +210,23 @@
 
 		e.preventDefault()
 
+		// Capture the bounding rectangle of the clicked element
+		const clickedElement = e.currentTarget as HTMLElement
+		const rect = clickedElement.getBoundingClientRect()
+		
+		// Convert DOMRect to plain object for serialization
+		const serializableRect = {
+			left: rect.left,
+			top: rect.top,
+			width: rect.width,
+			height: rect.height
+		}
+		
 		const href = `/recipe/${recipe.id}`
 		const result = await preloadData(href)
 
 		if (result.type === 'loaded' && result.status === 200) {
-			pushState(href, { recipeModal: result.data })
+			pushState(href, { recipeModal: result.data, animateFrom: serializableRect })
 		} else {
 			goto(href)
 		}
@@ -231,6 +240,7 @@
 
 	const closePopup = () => {
 		page.state.recipeModal = undefined
+		page.state.animateFrom = undefined
 		resolveRecipePopup()
 
 		history.back()
@@ -323,7 +333,6 @@
 							<Pill
 								text={`-${ingredient.label}`}
 								onRemove={() => removeIngredient(ingredient.label)}
-	animateFrom={popupFromRect}
 							/>
 						{/each}
 					</div>
@@ -360,6 +369,7 @@
 	data={page.state.recipeModal}
 	isOpen={page.state.recipeModal !== undefined}
 	onClose={closePopup}
+	animateFrom={page.state.animateFrom}
 />
 
 <style lang="scss">


### PR DESCRIPTION
## Summary
- add `<RecipePopup>` component for modal-based recipe previews
- enable shallow routing logic when clicking recipe cards
- open recipe cards in a popup on the homepage without iframes
- update `App.PageState` with flexible `recipeModal` type

## Testing
- `npx prettier --write src/app.d.ts src/lib/components/recipe-grid/RecipeGrid.svelte src/lib/components/recipe-popup/RecipePopup.svelte src/lib/pages/home/Home.svelte`

------
https://chatgpt.com/codex/tasks/task_e_685d0798ae28832185c8b8fe56bd8108