### PR TITLE
Improve recipe popup fullscreen transition

### DIFF
--- a/src/lib/components/recipe-popup/RecipePopup.svelte
+++ b/src/lib/components/recipe-popup/RecipePopup.svelte
@@ -2,7 +2,8 @@
 	import Popup from '../popup/Popup.svelte'
 	import ExternalLink from 'lucide-svelte/icons/external-link'
 	import RecipePage from '../../../routes/(pages)/recipe/[id]/+page.svelte'
-	import { goto } from '$app/navigation'
+       import { goto } from '$app/navigation'
+       import gsap from 'gsap'
 	import type { ComponentProps } from 'svelte'
 
 	let {
@@ -15,11 +16,49 @@
 		onClose: () => void
 	} = $props()
 
-	const openFullPage = (e: MouseEvent) => {
-		if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
-		e.preventDefault()
-		goto(window.location.href, { replaceState: false })
-	}
+       const openFullPage = async (e: MouseEvent) => {
+               if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return
+               e.preventDefault()
+
+               const overlay = document.querySelector<HTMLElement>('.popup-overlay')
+               const container = overlay?.querySelector<HTMLElement>('.popup-container')
+               const main = document.querySelector<HTMLElement>('.main')
+
+               if (!overlay || !container || !main) {
+                       goto(window.location.href, { replaceState: false })
+                       return
+               }
+
+               const mainRect = main.getBoundingClientRect()
+               const containerRect = container.getBoundingClientRect()
+
+               gsap.set(container, {
+                       position: 'fixed',
+                       top: containerRect.top,
+                       left: containerRect.left,
+                       width: containerRect.width,
+                       height: containerRect.height
+               })
+
+               const timeline = gsap.timeline({
+                       onComplete: () => goto(window.location.href, { replaceState: false })
+               })
+
+               timeline.to(overlay, { backgroundColor: 'transparent', duration: 0.3 }, 0)
+               timeline.to(
+                       container,
+                       {
+                               top: mainRect.top,
+                               left: mainRect.left,
+                               width: mainRect.width,
+                               height: mainRect.height,
+                               borderRadius: 0,
+                               duration: 0.3,
+                               ease: 'power1.inOut'
+                       },
+                       0
+               )
+       }
 </script>
 
 <Popup {isOpen} {onClose} width="90vw">


### PR DESCRIPTION
## Summary
- animate recipe popup transition into the main recipe page

## Testing
- `git pull` *(fails: no remote tracking branch)*

------
https://chatgpt.com/codex/tasks/task_e_68665994f1fc83219a0cf4b3e59b51d2