### PR TITLE
Display like count in floating button

### DIFF
--- a/src/lib/components/floating-action-button/FloatingLikeButton.svelte
+++ b/src/lib/components/floating-action-button/FloatingLikeButton.svelte
@@ -1,14 +1,22 @@
 <script lang="ts">
-	import Heart from 'lucide-svelte/icons/heart'
-	import FloatingActionButton from './FloatingActionButton.svelte'
+       import Heart from 'lucide-svelte/icons/heart'
+       import FloatingActionButton from './FloatingActionButton.svelte'
+       import { formatNumberShort } from '$lib/utils/format'
 
-	let { isActive = false, onClick, loading = false }: { isActive?: boolean; onClick?: () => void; loading?: boolean } = $props()
+       let {
+               count = 0,
+               isActive = false,
+               onClick,
+               loading = false
+       }: { count?: number; isActive?: boolean; onClick?: () => void; loading?: boolean } = $props()
+
+       const displayedCount = $derived(formatNumberShort(count))
 </script>
 
 <div class="like-button-container">
-	<FloatingActionButton text={isActive ? 'Liked' : 'Like'} {onClick} {isActive} {loading}>
-		<Heart />
-	</FloatingActionButton>
+       <FloatingActionButton text={displayedCount} {onClick} {isActive} {loading}>
+               <Heart />
+       </FloatingActionButton>
 </div>
 
 <style lang="scss">

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,8 @@
+export const formatNumberShort = (count: number): string => {
+  if (count >= 10000) {
+    return (count / 1000).toFixed(0) + 'K'
+  } else if (count >= 1000) {
+    return (count / 1000).toFixed(2) + 'K'
+  }
+  return count.toString()
+}


### PR DESCRIPTION
## Summary
- show number of likes on the floating like button
- update recipe page to track like count and use formatting helper
- add utility to format large numbers concisely

## Testing
- `git pull` *(fails: no tracking information)*

------
https://chatgpt.com/codex/tasks/task_e_686db8871d8083218fc05a847997b023