### PR TITLE
Add comment pagination

### DIFF
--- a/src/lib/components/comment/CommentList.svelte
+++ b/src/lib/components/comment/CommentList.svelte
@@ -12,7 +12,10 @@
 		isLoggedIn,
 		recipeId,
 		formError = null,
-		loading = false
+		loading = false,
+		page = 0,
+		hasMore = false,
+		onPageChange
 	}: {
 		comments: {
 			id: string
@@ -30,6 +33,9 @@
 		recipeId: string
 		formError?: string | null
 		loading?: boolean
+		page?: number
+		hasMore?: boolean
+		onPageChange?: (page: number) => void
 	} = $props()
 
 	let imagePreview = $state<string | null>(null)
@@ -178,6 +184,26 @@
 					imageUrl={comment.imageUrl}
 				/>
 			{/each}
+		{/if}
+	</div>
+	<div class="pagination-controls">
+		{#if page > 0}
+			<button
+				class="pagination-button"
+				on:click={() => onPageChange && onPageChange(page - 1)}
+				disabled={loading}
+			>
+				Previous
+			</button>
+		{/if}
+		{#if hasMore}
+			<button
+				class="pagination-button"
+				on:click={() => onPageChange && onPageChange(page + 1)}
+				disabled={loading}
+			>
+				Next
+			</button>
 		{/if}
 	</div>
 </div>
@@ -407,5 +433,20 @@
 
 	.comment-image-skeleton {
 		margin-top: var(--spacing-sm);
+	}
+
+	.pagination-controls {
+		display: flex;
+		justify-content: space-between;
+		margin-top: var(--spacing-lg);
+	}
+
+	.pagination-button {
+		background: none;
+		border: 1px solid rgba(255, 255, 255, 0.2);
+		color: var(--color-text-on-surface);
+		padding: var(--spacing-xs) var(--spacing-sm);
+		border-radius: var(--border-radius-sm);
+		cursor: pointer;
 	}
 </style>

--- a/src/lib/server/db/recipe-comments.ts
+++ b/src/lib/server/db/recipe-comments.ts
@@ -3,51 +3,59 @@ import { recipeComment, user } from './schema'
 import { eq, and, desc } from 'drizzle-orm'
 import { generateId } from '$lib/server/id'
 
-export async function addComment(recipeId: string, userId: string, content: string, imageUrl?: string) {
-  const commentId = generateId()
-  
-  const newComment = await db.insert(recipeComment).values({
-    id: commentId,
-    userId,
-    recipeId,
-    content,
-    imageUrl
-  }).returning()
-  
-  return newComment[0]
+export async function addComment(
+	recipeId: string,
+	userId: string,
+	content: string,
+	imageUrl?: string
+) {
+	const commentId = generateId()
+
+	const newComment = await db
+		.insert(recipeComment)
+		.values({
+			id: commentId,
+			userId,
+			recipeId,
+			content,
+			imageUrl
+		})
+		.returning()
+
+	return newComment[0]
 }
 
-export async function getComments(recipeId: string) {
-  const comments = await db
-    .select({
-      id: recipeComment.id,
-      content: recipeComment.content,
-      imageUrl: recipeComment.imageUrl,
-      createdAt: recipeComment.createdAt,
-      user: {
-        id: user.id,
-        username: user.username,
-        avatarUrl: user.avatarUrl
-      }
-    })
-    .from(recipeComment)
-    .innerJoin(user, eq(recipeComment.userId, user.id))
-    .where(eq(recipeComment.recipeId, recipeId))
-    .orderBy(desc(recipeComment.createdAt))
-  
-  return comments
+export async function getComments(recipeId: string, limit: number | undefined = 10, page = 0) {
+	let query = db
+		.select({
+			id: recipeComment.id,
+			content: recipeComment.content,
+			imageUrl: recipeComment.imageUrl,
+			createdAt: recipeComment.createdAt,
+			user: {
+				id: user.id,
+				username: user.username,
+				avatarUrl: user.avatarUrl
+			}
+		})
+		.from(recipeComment)
+		.innerJoin(user, eq(recipeComment.userId, user.id))
+		.where(eq(recipeComment.recipeId, recipeId))
+		.orderBy(desc(recipeComment.createdAt))
+
+	if (limit !== undefined) {
+		query = query.limit(limit).offset(page * limit)
+	}
+
+	const comments = await query
+	return comments
 }
 
 export async function deleteComment(commentId: string, userId: string) {
-  const deleted = await db
-    .delete(recipeComment)
-    .where(
-      and(
-        eq(recipeComment.id, commentId),
-        eq(recipeComment.userId, userId)
-      )
-    )
-    .returning()
-  
-  return deleted.length > 0
-} 
+	const deleted = await db
+		.delete(recipeComment)
+		.where(and(eq(recipeComment.id, commentId), eq(recipeComment.userId, userId)))
+		.returning()
+
+	return deleted.length > 0
+}

--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -68,6 +68,9 @@
 			isLoggedIn={!!data.user}
 			collections={data.collections.then((c) => c.map((c) => c.name))}
 			recipeComments={data.comments}
+			commentPage={data.commentsPage}
+			commentsHasMore={data.commentsHasMore}
+			onCommentPageChange={(p) => goto(`?page=${p}`)}
 			formError={page.form?.error}
 		/>
 	{:catch error}

--- a/src/routes/api/recipes/[id]/comments/+server.ts
+++ b/src/routes/api/recipes/[id]/comments/+server.ts
@@ -3,67 +3,69 @@ import type { RequestHandler } from './$types'
 import { getComments, addComment } from '$lib/server/db/recipe-comments'
 import * as v from 'valibot'
 
-export const GET: RequestHandler = async ({ params }) => {
-  const recipeId = params.id
-  
-  if (!recipeId) {
-    throw error(400, 'Recipe ID is required')
-  }
-  
-  try {
-    const comments = await getComments(recipeId)
-    return json(comments)
-  } catch (err) {
-    console.error('Error fetching comments:', err)
-    throw error(500, 'Failed to fetch comments')
-  }
+export const GET: RequestHandler = async ({ params, url }) => {
+	const recipeId = params.id
+
+	if (!recipeId) {
+		throw error(400, 'Recipe ID is required')
+	}
+
+	try {
+		const limit = parseInt(url.searchParams.get('limit') || '10', 10)
+		const page = parseInt(url.searchParams.get('page') || '0', 10)
+		const comments = await getComments(recipeId, limit, page)
+		return json(comments)
+	} catch (err) {
+		console.error('Error fetching comments:', err)
+		throw error(500, 'Failed to fetch comments')
+	}
 }
 
 const commentSchema = v.object({
-  content: v.pipe(
-    v.string(),
-    v.minLength(1, 'Comment cannot be empty'),
-    v.maxLength(1000, 'Comment is too long')
-  ),
-  imageUrl: v.optional(v.string())
+	content: v.pipe(
+		v.string(),
+		v.minLength(1, 'Comment cannot be empty'),
+		v.maxLength(1000, 'Comment is too long')
+	),
+	imageUrl: v.optional(v.string())
 })
 
 export const POST: RequestHandler = async ({ params, request, locals }) => {
-  const recipeId = params.id
-  
-  if (!recipeId) {
-    throw error(400, 'Recipe ID is required')
-  }
-  
-  if (!locals.user) {
-    throw error(401, 'You must be logged in to comment')
-  }
-  
-  try {
-    const body = await request.json()
-    const validatedData = v.parse(commentSchema, body)
-    
-    const newComment = await addComment(
-      recipeId, 
-      locals.user.id, 
-      validatedData.content,
-      validatedData.imageUrl
-    )
-    
-    // Fetch the complete comment with user info to return
-    const comments = await getComments(recipeId)
-    const createdComment = comments.find(comment => comment.id === newComment.id)
-    
-    if (!createdComment) {
-      throw error(500, 'Failed to retrieve created comment')
-    }
-    
-    return json(createdComment)
-  } catch (err) {
-    if (err instanceof v.ValiError) {
-      throw error(400, err.message)
-    }
-    console.error('Error adding comment:', err)
-    throw error(500, 'Failed to add comment')
-  }
-} 
+	const recipeId = params.id
+
+	if (!recipeId) {
+		throw error(400, 'Recipe ID is required')
+	}
+
+	if (!locals.user) {
+		throw error(401, 'You must be logged in to comment')
+	}
+
+	try {
+		const body = await request.json()
+		const validatedData = v.parse(commentSchema, body)
+
+		const newComment = await addComment(
+			recipeId,
+			locals.user.id,
+			validatedData.content,
+			validatedData.imageUrl
+		)
+
+		// Fetch the complete comment with user info to return
+		const comments = await getComments(recipeId)
+		const createdComment = comments.find((comment) => comment.id === newComment.id)
+
+		if (!createdComment) {
+			throw error(500, 'Failed to retrieve created comment')
+		}
+
+		return json(createdComment)
+	} catch (err) {
+		if (err instanceof v.ValiError) {
+			throw error(400, err.message)
+		}
+		console.error('Error adding comment:', err)
+		throw error(500, 'Failed to add comment')
+	}
+}


### PR DESCRIPTION
## Summary
- paginate recipe comments in DB layer
- support `page` and `limit` on comments API
- include comments page data in recipe page load
- hook up pagination controls in recipe pages
- show pagination buttons in comment list

## Testing
- `pnpm test` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68714c347048832185e9b55f81d9caa3