### PR TITLE
Implement comment pagination

### DIFF
--- a/src/lib/components/comment/CommentList.svelte
+++ b/src/lib/components/comment/CommentList.svelte
@@ -15,14 +15,14 @@
 		comments = [],
 		isLoggedIn,
 		recipeId,
-                formError = null,
-                loading = false,
-                onCommentAdded,
-                page = 0,
-                hasMore = false,
-                onNextPage,
-                onPrevPage
-        }: {
+		formError = null,
+		loading = false,
+		onCommentAdded,
+		page = 0,
+		hasMore = false,
+		onNextPage,
+		onPrevPage
+	}: {
 		comments: {
 			id: string
 			content: string
@@ -36,15 +36,15 @@
 		}[]
 		isLoggedIn: boolean
 		onAddComment?: (content: string, imageUrl?: string) => Promise<void>
-                recipeId: string
-                formError?: string | null
-                loading?: boolean
-                onCommentAdded?: () => void
-                page?: number
-                hasMore?: boolean
-                onNextPage?: () => void
-                onPrevPage?: () => void
-        } = $props()
+		recipeId: string
+		formError?: string | null
+		loading?: boolean
+		onCommentAdded?: () => void
+		page?: number
+		hasMore?: boolean
+		onNextPage?: () => void
+		onPrevPage?: () => void
+	} = $props()
 
 	let imagePreview = $state<string | null>(null)
 	let isSubmitting = $state(false)
@@ -104,9 +104,8 @@
 							cleanupPreview(imagePreview)
 							imagePreview = null
 						}
-						if (onCommentAdded) {
-							onCommentAdded()
-						}
+
+						onCommentAdded?.()
 					}
 				}
 			}}
@@ -215,7 +214,7 @@
 			</div>
 		{:else}
 			{#each comments as comment (comment.id)}
-				<div animate:flip|global={{ duration: 300 }} transition:fade|global={{ duration: 1000 }}>
+				<div animate:flip={{ duration: 300 }} transition:fade|global={{ duration: 1000 }}>
 					<Comment
 						username={comment.user.username}
 						content={comment.content}
@@ -225,14 +224,14 @@
 					/>
 					<div class="divider"></div>
 				</div>
-                        {/each}
-                {/if}
-        </div>
+			{/each}
+		{/if}
+	</div>
 
-        <div class="pagination">
-                <Button on:click={onPrevPage} disabled={page === 0}>Previous</Button>
-                <Button on:click={onNextPage} disabled={!hasMore}>Next</Button>
-        </div>
+	<div class="pagination">
+		<Button onclick={onPrevPage} disabled={page === 0}>Previous</Button>
+		<Button onclick={onNextPage} disabled={!hasMore}>Next</Button>
+	</div>
 </div>
 
 <style lang="scss">
@@ -431,13 +430,13 @@
 		gap: var(--spacing-xs);
 	}
 
-        .comment-image-skeleton {
-                margin-top: var(--spacing-sm);
-        }
+	.comment-image-skeleton {
+		margin-top: var(--spacing-sm);
+	}
 
-        .pagination {
-                display: flex;
-                justify-content: space-between;
-                margin-top: var(--spacing-lg);
-        }
+	.pagination {
+		display: flex;
+		justify-content: space-between;
+		margin-top: var(--spacing-lg);
+	}
 </style>

--- a/src/lib/components/comment/CommentList.svelte
+++ b/src/lib/components/comment/CommentList.svelte
@@ -15,10 +15,14 @@
 		comments = [],
 		isLoggedIn,
 		recipeId,
-		formError = null,
-		loading = false,
-		onCommentAdded
-	}: {
+                formError = null,
+                loading = false,
+                onCommentAdded,
+                page = 0,
+                hasMore = false,
+                onNextPage,
+                onPrevPage
+        }: {
 		comments: {
 			id: string
 			content: string
@@ -32,11 +36,15 @@
 		}[]
 		isLoggedIn: boolean
 		onAddComment?: (content: string, imageUrl?: string) => Promise<void>
-		recipeId: string
-		formError?: string | null
-		loading?: boolean
-		onCommentAdded?: () => void
-	} = $props()
+                recipeId: string
+                formError?: string | null
+                loading?: boolean
+                onCommentAdded?: () => void
+                page?: number
+                hasMore?: boolean
+                onNextPage?: () => void
+                onPrevPage?: () => void
+        } = $props()
 
 	let imagePreview = $state<string | null>(null)
 	let isSubmitting = $state(false)
@@ -217,9 +225,14 @@
 					/>
 					<div class="divider"></div>
 				</div>
-			{/each}
-		{/if}
-	</div>
+                        {/each}
+                {/if}
+        </div>
+
+        <div class="pagination">
+                <Button on:click={onPrevPage} disabled={page === 0}>Previous</Button>
+                <Button on:click={onNextPage} disabled={!hasMore}>Next</Button>
+        </div>
 </div>
 
 <style lang="scss">
@@ -418,7 +431,13 @@
 		gap: var(--spacing-xs);
 	}
 
-	.comment-image-skeleton {
-		margin-top: var(--spacing-sm);
-	}
+        .comment-image-skeleton {
+                margin-top: var(--spacing-sm);
+        }
+
+        .pagination {
+                display: flex;
+                justify-content: space-between;
+                margin-top: var(--spacing-lg);
+        }
 </style>

--- a/src/lib/pages/recipe/Recipe.svelte
+++ b/src/lib/pages/recipe/Recipe.svelte
@@ -41,8 +41,12 @@
 		onBackClick,
 		recipeComments = Promise.resolve([]),
 		formError,
-		onCommentAdded
-	}: {
+                onCommentAdded,
+                page = 0,
+                hasMore = false,
+                onNextPage,
+                onPrevPage
+        }: {
 		recipe: Promise<DetailedRecipe>
 		nutritionInfo: {
 			totalNutrition: Omit<NutritionInfo, 'servingSize'>
@@ -58,8 +62,12 @@
 		onBackClick?: () => void
 		recipeComments?: Promise<ComponentProps<typeof CommentList>['comments']>
 		formError?: string
-		onCommentAdded?: () => void
-	} = $props()
+                onCommentAdded?: () => void
+                page?: number
+                hasMore?: boolean
+                onNextPage?: () => void
+                onPrevPage?: () => void
+        } = $props()
 
 	let isLiked = $derived.by(() => recipe.then((r) => r.isLiked))
 	let isSaved = $derived.by(() => recipe.then((r) => r.isSaved))
@@ -334,9 +342,9 @@
 			</h3>
 		</div>
 		{#await Promise.all([recipe, recipeComments])}
-			<CommentList comments={[]} {isLoggedIn} recipeId="" {formError} loading={true} onCommentAdded={onCommentAdded} />
+                    <CommentList comments={[]} {isLoggedIn} recipeId="" {formError} loading={true} onCommentAdded={onCommentAdded} page={0} hasMore={false} />
 		{:then [recipe, comments]}
-			<CommentList {comments} {isLoggedIn} recipeId={recipe.id} {formError} onCommentAdded={onCommentAdded} />
+                    <CommentList {comments} {isLoggedIn} recipeId={recipe.id} {formError} onCommentAdded={onCommentAdded} page={page} hasMore={hasMore} onNextPage={nextPage} onPrevPage={prevPage} />
 		{/await}
 	</div>
 {/snippet}

--- a/src/lib/pages/recipe/Recipe.svelte
+++ b/src/lib/pages/recipe/Recipe.svelte
@@ -41,12 +41,12 @@
 		onBackClick,
 		recipeComments = Promise.resolve([]),
 		formError,
-                onCommentAdded,
-                page = 0,
-                hasMore = false,
-                onNextPage,
-                onPrevPage
-        }: {
+		onCommentAdded,
+		page = 0,
+		hasMore = false,
+		onNextPage,
+		onPrevPage
+	}: {
 		recipe: Promise<DetailedRecipe>
 		nutritionInfo: {
 			totalNutrition: Omit<NutritionInfo, 'servingSize'>
@@ -62,12 +62,12 @@
 		onBackClick?: () => void
 		recipeComments?: Promise<ComponentProps<typeof CommentList>['comments']>
 		formError?: string
-                onCommentAdded?: () => void
-                page?: number
-                hasMore?: boolean
-                onNextPage?: () => void
-                onPrevPage?: () => void
-        } = $props()
+		onCommentAdded?: () => void
+		page?: number
+		hasMore?: boolean
+		onNextPage?: () => void
+		onPrevPage?: () => void
+	} = $props()
 
 	let isLiked = $derived.by(() => recipe.then((r) => r.isLiked))
 	let isSaved = $derived.by(() => recipe.then((r) => r.isSaved))
@@ -342,19 +342,28 @@
 			</h3>
 		</div>
 		{#await Promise.all([recipe, recipeComments])}
-                    <CommentList comments={[]} {isLoggedIn} recipeId="" {formError} loading={true} onCommentAdded={onCommentAdded} page={0} hasMore={false} />
+			<CommentList
+				comments={[]}
+				{isLoggedIn}
+				recipeId=""
+				{formError}
+				loading={true}
+				{onCommentAdded}
+				page={0}
+				hasMore={false}
+			/>
 		{:then [recipe, comments]}
-                    <CommentList
-                            {comments}
-                            {isLoggedIn}
-                            recipeId={recipe.id}
-                            {formError}
-                            onCommentAdded={onCommentAdded}
-                            page={page}
-                            hasMore={hasMore}
-                            onNextPage={onNextPage}
-                            onPrevPage={onPrevPage}
-                    />
+			<CommentList
+				{comments}
+				{isLoggedIn}
+				recipeId={recipe.id}
+				{formError}
+				{onCommentAdded}
+				{page}
+				{hasMore}
+				{onNextPage}
+				{onPrevPage}
+			/>
 		{/await}
 	</div>
 {/snippet}

--- a/src/lib/pages/recipe/Recipe.svelte
+++ b/src/lib/pages/recipe/Recipe.svelte
@@ -344,7 +344,17 @@
 		{#await Promise.all([recipe, recipeComments])}
                     <CommentList comments={[]} {isLoggedIn} recipeId="" {formError} loading={true} onCommentAdded={onCommentAdded} page={0} hasMore={false} />
 		{:then [recipe, comments]}
-                    <CommentList {comments} {isLoggedIn} recipeId={recipe.id} {formError} onCommentAdded={onCommentAdded} page={page} hasMore={hasMore} onNextPage={nextPage} onPrevPage={prevPage} />
+                    <CommentList
+                            {comments}
+                            {isLoggedIn}
+                            recipeId={recipe.id}
+                            {formError}
+                            onCommentAdded={onCommentAdded}
+                            page={page}
+                            hasMore={hasMore}
+                            onNextPage={onNextPage}
+                            onPrevPage={onPrevPage}
+                    />
 		{/await}
 	</div>
 {/snippet}

--- a/src/lib/server/db/recipe-comments.ts
+++ b/src/lib/server/db/recipe-comments.ts
@@ -17,8 +17,12 @@ export async function addComment(recipeId: string, userId: string, content: stri
   return newComment[0]
 }
 
-export async function getComments(recipeId: string) {
-  const comments = await db
+export async function getComments(
+  recipeId: string,
+  limit?: number,
+  page = 0
+) {
+  let query = db
     .select({
       id: recipeComment.id,
       content: recipeComment.content,
@@ -34,7 +38,13 @@ export async function getComments(recipeId: string) {
     .innerJoin(user, eq(recipeComment.userId, user.id))
     .where(eq(recipeComment.recipeId, recipeId))
     .orderBy(desc(recipeComment.createdAt))
-  
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit).offset(page * limit)
+  }
+
+  const comments = await query
+
   return comments
 }
 

--- a/src/routes/(pages)/recipe/[id]/+page.server.ts
+++ b/src/routes/(pages)/recipe/[id]/+page.server.ts
@@ -6,7 +6,7 @@ import * as v from 'valibot'
 import { getCollections } from '$lib/server/db/save'
 import { safeFetch } from '$lib/utils/fetch'
 
-export const load: PageServerLoad = ({ params, locals, fetch }) => {
+export const load: PageServerLoad = ({ params, locals, fetch, url }) => {
   const recipe = getRecipeWithDetails(params.id, locals.user?.id).then(
     (result) => {
       if (!result) throw error(404, 'Recipe not found')
@@ -14,7 +14,8 @@ export const load: PageServerLoad = ({ params, locals, fetch }) => {
     }
   )
 
-  const comments = safeFetch(fetch)(`/api/recipes/${params.id}/comments`).then((result) => {
+  const page = parseInt(url.searchParams.get('page') || '0', 10)
+  const comments = safeFetch(fetch)(`/api/recipes/${params.id}/comments?page=${page}`).then((result) => {
     if (result.isErr()) {
       console.error('Failed to fetch comments:', result.error)
       return []

--- a/src/routes/(pages)/recipe/[id]/+page.server.ts
+++ b/src/routes/(pages)/recipe/[id]/+page.server.ts
@@ -5,6 +5,7 @@ import { uploadImage } from '$lib/server/cloudinary'
 import * as v from 'valibot'
 import { getCollections } from '$lib/server/db/save'
 import { safeFetch } from '$lib/utils/fetch'
+import type { Comments } from '../../../api/recipes/[id]/comments/+server'
 
 export const load: PageServerLoad = ({ params, locals, fetch, url }) => {
   const recipe = getRecipeWithDetails(params.id, locals.user?.id).then(
@@ -14,8 +15,7 @@ export const load: PageServerLoad = ({ params, locals, fetch, url }) => {
     }
   )
 
-  const page = parseInt(url.searchParams.get('page') || '0', 10)
-  const comments = safeFetch(fetch)(`/api/recipes/${params.id}/comments?page=${page}`).then((result) => {
+  const comments = safeFetch<Comments>(fetch)(`/api/recipes/${params.id}/comments?page=0`).then((result) => {
     if (result.isErr()) {
       console.error('Failed to fetch comments:', result.error)
       return []

--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-        import { goto} from '$app/navigation'
+	import { goto } from '$app/navigation'
 	import Recipe from '$lib/pages/recipe/Recipe.svelte'
 	import { unitPreferenceStore, type UnitSystem } from '$lib/state/unitPreference.svelte'
 	import { page } from '$app/state'
@@ -7,19 +7,20 @@
 	import type { RecipesLikeResponse } from '../../../api/recipes/like/+server.js'
 	import type { RecipesSaveResponse } from '../../../api/recipes/save/+server.js'
 	import type { CollectionsResponse } from '../../../api/collections/+server.js'
-	
-        const COMMENTS_PER_PAGE = 10
+	import type { Comments } from '../../../api/recipes/[id]/comments/+server.js'
 
-        let { data } = $props()
-        let comments = $state(data.comments)
-        let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
-        let hasMore = $state(false)
+	const COMMENTS_PER_PAGE = 10
 
-        $effect(() => {
-                data.comments.then((c) => {
-                        hasMore = c.length === COMMENTS_PER_PAGE
-                })
-        })
+	let { data } = $props()
+	let comments = $state(data.comments)
+	let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
+	let hasMore = $state(false)
+
+	$effect(() => {
+		data.comments.then((c) => {
+			hasMore = c.length === COMMENTS_PER_PAGE
+		})
+	})
 
 	const handleLike = async () => {
 		await safeFetch<RecipesLikeResponse>()(`/api/recipes/like`, {
@@ -59,30 +60,29 @@
 		}
 	}
 
-        const loadPage = async (pageNum: number) => {
-                const result = await safeFetch<{ id: string; content: string; createdAt: string | Date; imageUrl?: string | null; user: { id: string; username: string; avatarUrl: string | null; }[] }>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
-                if (result.isOk()) {
-                        comments = Promise.resolve(result.value)
-                        hasMore = result.value.length === COMMENTS_PER_PAGE
-                        currentPage = pageNum
-                        goto(`?page=${pageNum}`, { replaceState: true, keepfocus: true, noScroll: true })
-                }
-        }
+	const loadComments = async (pageNum: number) => {
+		const result = await safeFetch<Comments>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
+		if (result.isOk()) {
+			comments = Promise.resolve(result.value)
+			hasMore = result.value.length === COMMENTS_PER_PAGE
+			currentPage = pageNum
+		}
+	}
 
-        const nextPage = async () => {
-                if (!hasMore) return
-                await loadPage(currentPage + 1)
-        }
+	const nextPage = async () => {
+		if (!hasMore) return
+		await loadComments(currentPage + 1)
+	}
 
-        const prevPage = async () => {
-                if (currentPage === 0) return
-                await loadPage(currentPage - 1)
-        }
+	const prevPage = async () => {
+		if (currentPage === 0) return
+		await loadComments(currentPage - 1)
+	}
 
-        const handleCommentAdded = async () => {
-                await loadPage(0)
-        }
-	
+	const handleCommentAdded = async () => {
+		await loadComments(0)
+	}
+
 	const unitSystem = $derived(unitPreferenceStore.unitSystem)
 </script>
 
@@ -99,14 +99,14 @@
 		onSave={handleSave}
 		onBackClick={() => goto('/')}
 		onCreateCollection={createCollection}
-                isLoggedIn={!!data.user}
-                collections={data.collections.then((c) => c.map((c) => c.name))}
-                recipeComments={comments}
-                formError={page.form?.error}
-                onCommentAdded={handleCommentAdded}
-                page={currentPage}
-                hasMore={hasMore}
-                onNextPage={nextPage}
-                onPrevPage={prevPage}
-        />
+		isLoggedIn={!!data.user}
+		collections={data.collections.then((c) => c.map((c) => c.name))}
+		recipeComments={comments}
+		formError={page.form?.error}
+		onCommentAdded={handleCommentAdded}
+		page={currentPage}
+		{hasMore}
+		onNextPage={nextPage}
+		onPrevPage={prevPage}
+	/>
 </div>

--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto} from '$app/navigation'
+        import { goto} from '$app/navigation'
 	import Recipe from '$lib/pages/recipe/Recipe.svelte'
 	import { unitPreferenceStore, type UnitSystem } from '$lib/state/unitPreference.svelte'
 	import { page } from '$app/state'
@@ -8,8 +8,18 @@
 	import type { RecipesSaveResponse } from '../../../api/recipes/save/+server.js'
 	import type { CollectionsResponse } from '../../../api/collections/+server.js'
 	
-	let { data } = $props()
-	let comments = $state(data.comments)
+        const COMMENTS_PER_PAGE = 10
+
+        let { data } = $props()
+        let comments = $state(data.comments)
+        let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
+        let hasMore = $state(false)
+
+        $effect(() => {
+                data.comments.then((c) => {
+                        hasMore = c.length === COMMENTS_PER_PAGE
+                })
+        })
 
 	const handleLike = async () => {
 		await safeFetch<RecipesLikeResponse>()(`/api/recipes/like`, {
@@ -49,12 +59,29 @@
 		}
 	}
 
-	const handleCommentAdded = async () => {
-		const result = await safeFetch<{ id: string; content: string; createdAt: string | Date; imageUrl?: string | null; user: { id: string; username: string; avatarUrl: string | null; }[] }>()(`/api/recipes/${(await data.recipe).id}/comments`)
-		if (result.isOk()) {
-			comments = Promise.resolve(result.value)
-		}
-	}
+        const loadPage = async (pageNum: number) => {
+                const result = await safeFetch<{ id: string; content: string; createdAt: string | Date; imageUrl?: string | null; user: { id: string; username: string; avatarUrl: string | null; }[] }>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
+                if (result.isOk()) {
+                        comments = Promise.resolve(result.value)
+                        hasMore = result.value.length === COMMENTS_PER_PAGE
+                        currentPage = pageNum
+                        goto(`?page=${pageNum}`, { replaceState: true, keepfocus: true, noScroll: true })
+                }
+        }
+
+        const nextPage = async () => {
+                if (!hasMore) return
+                await loadPage(currentPage + 1)
+        }
+
+        const prevPage = async () => {
+                if (currentPage === 0) return
+                await loadPage(currentPage - 1)
+        }
+
+        const handleCommentAdded = async () => {
+                await loadPage(0)
+        }
 	
 	const unitSystem = $derived(unitPreferenceStore.unitSystem)
 </script>
@@ -72,10 +99,14 @@
 		onSave={handleSave}
 		onBackClick={() => goto('/')}
 		onCreateCollection={createCollection}
-		isLoggedIn={!!data.user}
-		collections={data.collections.then((c) => c.map((c) => c.name))}
-		recipeComments={comments}
-		formError={page.form?.error}
-		onCommentAdded={handleCommentAdded}
-	/>
+                isLoggedIn={!!data.user}
+                collections={data.collections.then((c) => c.map((c) => c.name))}
+                recipeComments={comments}
+                formError={page.form?.error}
+                onCommentAdded={handleCommentAdded}
+                page={currentPage}
+                hasMore={hasMore}
+                onNextPage={nextPage}
+                onPrevPage={prevPage}
+        />
 </div>

--- a/src/routes/api/recipes/[id]/comments/+server.ts
+++ b/src/routes/api/recipes/[id]/comments/+server.ts
@@ -3,15 +3,17 @@ import type { RequestHandler } from './$types'
 import { getComments, addComment } from '$lib/server/db/recipe-comments'
 import * as v from 'valibot'
 
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, url }) => {
   const recipeId = params.id
-  
+
   if (!recipeId) {
     throw error(400, 'Recipe ID is required')
   }
-  
+
   try {
-    const comments = await getComments(recipeId)
+    const limit = parseInt(url.searchParams.get('limit') || '10', 10)
+    const page = parseInt(url.searchParams.get('page') || '0', 10)
+    const comments = await getComments(recipeId, limit, page)
     return json(comments)
   } catch (err) {
     console.error('Error fetching comments:', err)

--- a/src/routes/api/recipes/[id]/comments/+server.ts
+++ b/src/routes/api/recipes/[id]/comments/+server.ts
@@ -3,6 +3,18 @@ import type { RequestHandler } from './$types'
 import { getComments, addComment } from '$lib/server/db/recipe-comments'
 import * as v from 'valibot'
 
+export type Comments = {
+  id: string
+  content: string
+  imageUrl?: string
+  createdAt: Date
+  user: {
+    id: string
+    username: string
+    avatarUrl?: string
+  }
+}[]
+
 export const GET: RequestHandler = async ({ params, url }) => {
   const recipeId = params.id
 
@@ -10,15 +22,10 @@ export const GET: RequestHandler = async ({ params, url }) => {
     throw error(400, 'Recipe ID is required')
   }
 
-  try {
-    const limit = parseInt(url.searchParams.get('limit') || '10', 10)
-    const page = parseInt(url.searchParams.get('page') || '0', 10)
-    const comments = await getComments(recipeId, limit, page)
-    return json(comments)
-  } catch (err) {
-    console.error('Error fetching comments:', err)
-    throw error(500, 'Failed to fetch comments')
-  }
+  const limit = parseInt(url.searchParams.get('limit') || '10', 10)
+  const page = parseInt(url.searchParams.get('page') || '0', 10)
+  const comments = await getComments(recipeId, limit, page) satisfies Comments
+  return json(comments)
 }
 
 const commentSchema = v.object({
@@ -32,34 +39,34 @@ const commentSchema = v.object({
 
 export const POST: RequestHandler = async ({ params, request, locals }) => {
   const recipeId = params.id
-  
+
   if (!recipeId) {
     throw error(400, 'Recipe ID is required')
   }
-  
+
   if (!locals.user) {
     throw error(401, 'You must be logged in to comment')
   }
-  
+
   try {
     const body = await request.json()
     const validatedData = v.parse(commentSchema, body)
-    
+
     const newComment = await addComment(
-      recipeId, 
-      locals.user.id, 
+      recipeId,
+      locals.user.id,
       validatedData.content,
       validatedData.imageUrl
     )
-    
+
     // Fetch the complete comment with user info to return
     const comments = await getComments(recipeId)
     const createdComment = comments.find(comment => comment.id === newComment.id)
-    
+
     if (!createdComment) {
       throw error(500, 'Failed to retrieve created comment')
     }
-    
+
     return json(createdComment)
   } catch (err) {
     if (err instanceof v.ValiError) {


### PR DESCRIPTION
## Summary
- add pagination support in comment API and DB
- fetch comments per page in recipe page load and UI
- show Next/Previous buttons in comment list

## Testing
- `pnpm check` *(fails: svelte-check found 77 errors)*
- `npx tsc --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68716043a49c8321bb6e035ff34d1e4d