### PR TITLE
Update comments pagination display

### DIFF
--- a/src/lib/components/comment/CommentList.svelte
+++ b/src/lib/components/comment/CommentList.svelte
@@ -7,11 +7,10 @@
 	import Button from '../button/Button.svelte'
 	import Skeleton from '../skeleton/Skeleton.svelte'
 	import Input from '../input/Input.svelte'
-import { invalidate, invalidateAll } from '$app/navigation'
-import { flip } from 'svelte/animate'
-import { fade } from 'svelte/transition'
+	import { flip } from 'svelte/animate'
+	import { fade } from 'svelte/transition'
 
-const COMMENTS_PER_PAGE = 10
+	const COMMENTS_PER_PAGE = 10
 
 	let {
 		comments = [],
@@ -23,9 +22,9 @@ const COMMENTS_PER_PAGE = 10
 		page = 0,
 		hasMore = false,
 		onNextPage,
-                onPrevPage,
-                total = 0
-        }: {
+		onPrevPage,
+		total = 0
+	}: {
 		comments: {
 			id: string
 			content: string
@@ -46,16 +45,16 @@ const COMMENTS_PER_PAGE = 10
 		page?: number
 		hasMore?: boolean
 		onNextPage?: () => void
-                onPrevPage?: () => void,
-                total?: number
-        } = $props()
+		onPrevPage?: () => void
+		total?: number
+	} = $props()
 
 	let imagePreview = $state<string | null>(null)
 	let isSubmitting = $state(false)
 	let imageError = $state<string | null>(null)
-        let commentContent = $state('')
+	let commentContent = $state('')
 
-        $: totalPages = Math.max(1, Math.ceil(total / COMMENTS_PER_PAGE))
+	const totalPages = $derived(Math.max(1, Math.ceil(total / COMMENTS_PER_PAGE)))
 
 	async function handleImageSelect(event: Event) {
 		const input = event.target as HTMLInputElement
@@ -234,11 +233,11 @@ const COMMENTS_PER_PAGE = 10
 		{/if}
 	</div>
 
-        <div class="pagination">
-                <Button onclick={onPrevPage} disabled={page === 0}>Previous</Button>
-                <span class="page-info">Page {page + 1} of {totalPages}</span>
-                <Button onclick={onNextPage} disabled={!hasMore}>Next</Button>
-        </div>
+	<div class="pagination">
+		<Button onclick={onPrevPage} disabled={page === 0}>Previous</Button>
+		<span class="page-info">Page {page + 1} of {totalPages}</span>
+		<Button onclick={onNextPage} disabled={!hasMore}>Next</Button>
+	</div>
 </div>
 
 <style lang="scss">
@@ -441,14 +440,14 @@ const COMMENTS_PER_PAGE = 10
 		margin-top: var(--spacing-sm);
 	}
 
-        .pagination {
-                display: flex;
-                justify-content: space-between;
-                margin-top: var(--spacing-lg);
-        }
+	.pagination {
+		display: flex;
+		justify-content: space-between;
+		margin-top: var(--spacing-lg);
+	}
 
-        .page-info {
-                display: flex;
-                align-items: center;
-        }
+	.page-info {
+		display: flex;
+		align-items: center;
+	}
 </style>

--- a/src/lib/components/comment/CommentList.svelte
+++ b/src/lib/components/comment/CommentList.svelte
@@ -7,9 +7,11 @@
 	import Button from '../button/Button.svelte'
 	import Skeleton from '../skeleton/Skeleton.svelte'
 	import Input from '../input/Input.svelte'
-	import { invalidate, invalidateAll } from '$app/navigation'
-	import { flip } from 'svelte/animate'
-	import { fade } from 'svelte/transition'
+import { invalidate, invalidateAll } from '$app/navigation'
+import { flip } from 'svelte/animate'
+import { fade } from 'svelte/transition'
+
+const COMMENTS_PER_PAGE = 10
 
 	let {
 		comments = [],
@@ -21,8 +23,9 @@
 		page = 0,
 		hasMore = false,
 		onNextPage,
-		onPrevPage
-	}: {
+                onPrevPage,
+                total = 0
+        }: {
 		comments: {
 			id: string
 			content: string
@@ -43,13 +46,16 @@
 		page?: number
 		hasMore?: boolean
 		onNextPage?: () => void
-		onPrevPage?: () => void
-	} = $props()
+                onPrevPage?: () => void,
+                total?: number
+        } = $props()
 
 	let imagePreview = $state<string | null>(null)
 	let isSubmitting = $state(false)
 	let imageError = $state<string | null>(null)
-	let commentContent = $state('')
+        let commentContent = $state('')
+
+        $: totalPages = Math.max(1, Math.ceil(total / COMMENTS_PER_PAGE))
 
 	async function handleImageSelect(event: Event) {
 		const input = event.target as HTMLInputElement
@@ -228,10 +234,11 @@
 		{/if}
 	</div>
 
-	<div class="pagination">
-		<Button onclick={onPrevPage} disabled={page === 0}>Previous</Button>
-		<Button onclick={onNextPage} disabled={!hasMore}>Next</Button>
-	</div>
+        <div class="pagination">
+                <Button onclick={onPrevPage} disabled={page === 0}>Previous</Button>
+                <span class="page-info">Page {page + 1} of {totalPages}</span>
+                <Button onclick={onNextPage} disabled={!hasMore}>Next</Button>
+        </div>
 </div>
 
 <style lang="scss">
@@ -434,9 +441,14 @@
 		margin-top: var(--spacing-sm);
 	}
 
-	.pagination {
-		display: flex;
-		justify-content: space-between;
-		margin-top: var(--spacing-lg);
-	}
+        .pagination {
+                display: flex;
+                justify-content: space-between;
+                margin-top: var(--spacing-lg);
+        }
+
+        .page-info {
+                display: flex;
+                align-items: center;
+        }
 </style>

--- a/src/lib/pages/recipe/Recipe.svelte
+++ b/src/lib/pages/recipe/Recipe.svelte
@@ -60,7 +60,10 @@
 		isLoggedIn: boolean
 		onCreateCollection: (name: string) => Promise<void>
 		onBackClick?: () => void
-		recipeComments?: Promise<{ comments: ComponentProps<typeof CommentList>['comments']; total: number }>
+		recipeComments?: Promise<{
+			comments: ComponentProps<typeof CommentList>['comments']
+			total: number
+		}>
 		formError?: string
 		onCommentAdded?: () => void
 		page?: number
@@ -334,39 +337,39 @@
 			<h3 style:display="flex" style:align-items="center" style:gap="var(--spacing-sm)">
 				<MessageSquare size={20} />
 				Comments
-                                {#await recipeComments then res}
-                                        <span style:font-size="var(--font-size-xl)" style:font-weight="500">
-                                                ({res.total ?? '0'})
-                                        </span>
-                                {/await}
+				{#await recipeComments then res}
+					<span style:font-size="var(--font-size-xl)" style:font-weight="500">
+						({res.total ?? '0'})
+					</span>
+				{/await}
 			</h3>
 		</div>
-                {#await Promise.all([recipe, recipeComments])}
-                        <CommentList
-                                comments={[]}
-                                {isLoggedIn}
-                                recipeId=""
-                                {formError}
-                                loading={true}
-                                {onCommentAdded}
-                                page={0}
-                                hasMore={false}
-                                total={0}
-                        />
-                {:then [recipe, res]}
-                        <CommentList
-                                comments={res.comments}
-                                {isLoggedIn}
-                                recipeId={recipe.id}
-                                {formError}
-                                {onCommentAdded}
-                                {page}
-                                {hasMore}
-                                total={res.total}
-                                {onNextPage}
-                                {onPrevPage}
-                        />
-                {/await}
+		{#await Promise.all([recipe, recipeComments])}
+			<CommentList
+				comments={[]}
+				{isLoggedIn}
+				recipeId=""
+				{formError}
+				loading={true}
+				{onCommentAdded}
+				page={0}
+				hasMore={false}
+				total={0}
+			/>
+		{:then [recipe, res]}
+			<CommentList
+				comments={res.comments}
+				{isLoggedIn}
+				recipeId={recipe.id}
+				{formError}
+				{onCommentAdded}
+				{page}
+				{hasMore}
+				total={res.total}
+				{onNextPage}
+				{onPrevPage}
+			/>
+		{/await}
 	</div>
 {/snippet}
 

--- a/src/lib/pages/recipe/Recipe.svelte
+++ b/src/lib/pages/recipe/Recipe.svelte
@@ -39,7 +39,7 @@
 		isLoggedIn,
 		onCreateCollection,
 		onBackClick,
-		recipeComments = Promise.resolve([]),
+		recipeComments = Promise.resolve({ comments: [], total: 0 }),
 		formError,
 		onCommentAdded,
 		page = 0,
@@ -60,7 +60,7 @@
 		isLoggedIn: boolean
 		onCreateCollection: (name: string) => Promise<void>
 		onBackClick?: () => void
-		recipeComments?: Promise<ComponentProps<typeof CommentList>['comments']>
+		recipeComments?: Promise<{ comments: ComponentProps<typeof CommentList>['comments']; total: number }>
 		formError?: string
 		onCommentAdded?: () => void
 		page?: number
@@ -334,37 +334,39 @@
 			<h3 style:display="flex" style:align-items="center" style:gap="var(--spacing-sm)">
 				<MessageSquare size={20} />
 				Comments
-				{#await recipeComments then comments}
-					<span style:font-size="var(--font-size-xl)" style:font-weight="500">
-						({comments.length ?? '0'})
-					</span>
-				{/await}
+                                {#await recipeComments then res}
+                                        <span style:font-size="var(--font-size-xl)" style:font-weight="500">
+                                                ({res.total ?? '0'})
+                                        </span>
+                                {/await}
 			</h3>
 		</div>
-		{#await Promise.all([recipe, recipeComments])}
-			<CommentList
-				comments={[]}
-				{isLoggedIn}
-				recipeId=""
-				{formError}
-				loading={true}
-				{onCommentAdded}
-				page={0}
-				hasMore={false}
-			/>
-		{:then [recipe, comments]}
-			<CommentList
-				{comments}
-				{isLoggedIn}
-				recipeId={recipe.id}
-				{formError}
-				{onCommentAdded}
-				{page}
-				{hasMore}
-				{onNextPage}
-				{onPrevPage}
-			/>
-		{/await}
+                {#await Promise.all([recipe, recipeComments])}
+                        <CommentList
+                                comments={[]}
+                                {isLoggedIn}
+                                recipeId=""
+                                {formError}
+                                loading={true}
+                                {onCommentAdded}
+                                page={0}
+                                hasMore={false}
+                                total={0}
+                        />
+                {:then [recipe, res]}
+                        <CommentList
+                                comments={res.comments}
+                                {isLoggedIn}
+                                recipeId={recipe.id}
+                                {formError}
+                                {onCommentAdded}
+                                {page}
+                                {hasMore}
+                                total={res.total}
+                                {onNextPage}
+                                {onPrevPage}
+                        />
+                {/await}
 	</div>
 {/snippet}
 

--- a/src/lib/server/db/recipe-comments.ts
+++ b/src/lib/server/db/recipe-comments.ts
@@ -1,6 +1,6 @@
 import { db } from '.'
 import { recipeComment, user } from './schema'
-import { eq, and, desc } from 'drizzle-orm'
+import { eq, and, desc, sql } from 'drizzle-orm'
 import { generateId } from '$lib/server/id'
 
 export async function addComment(recipeId: string, userId: string, content: string, imageUrl?: string) {
@@ -60,4 +60,13 @@ export async function deleteComment(commentId: string, userId: string) {
     .returning()
   
   return deleted.length > 0
-} 
+}
+
+export async function getCommentCount(recipeId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(recipeComment)
+    .where(eq(recipeComment.recipeId, recipeId))
+
+  return result[0]?.count || 0
+}

--- a/src/lib/server/db/recipe-comments.ts
+++ b/src/lib/server/db/recipe-comments.ts
@@ -5,7 +5,7 @@ import { generateId } from '$lib/server/id'
 
 export async function addComment(recipeId: string, userId: string, content: string, imageUrl?: string) {
   const commentId = generateId()
-  
+
   const newComment = await db.insert(recipeComment).values({
     id: commentId,
     userId,
@@ -13,7 +13,7 @@ export async function addComment(recipeId: string, userId: string, content: stri
     content,
     imageUrl
   }).returning()
-  
+
   return newComment[0]
 }
 
@@ -58,7 +58,7 @@ export async function deleteComment(commentId: string, userId: string) {
       )
     )
     .returning()
-  
+
   return deleted.length > 0
 }
 

--- a/src/routes/(pages)/recipe/[id]/+page.server.ts
+++ b/src/routes/(pages)/recipe/[id]/+page.server.ts
@@ -5,9 +5,9 @@ import { uploadImage } from '$lib/server/cloudinary'
 import * as v from 'valibot'
 import { getCollections } from '$lib/server/db/save'
 import { safeFetch } from '$lib/utils/fetch'
-import type { Comments } from '../../../api/recipes/[id]/comments/+server'
+import type { CommentsResponse } from '../../../api/recipes/[id]/comments/+server'
 
-export const load: PageServerLoad = ({ params, locals, fetch, url }) => {
+export const load: PageServerLoad = ({ params, locals, fetch }) => {
   const recipe = getRecipeWithDetails(params.id, locals.user?.id).then(
     (result) => {
       if (!result) throw error(404, 'Recipe not found')
@@ -15,10 +15,10 @@ export const load: PageServerLoad = ({ params, locals, fetch, url }) => {
     }
   )
 
-  const comments = safeFetch<Comments>(fetch)(`/api/recipes/${params.id}/comments?page=0`).then((result) => {
+  const comments = safeFetch<CommentsResponse>(fetch)(`/api/recipes/${params.id}/comments?page=0`).then((result) => {
     if (result.isErr()) {
       console.error('Failed to fetch comments:', result.error)
-      return []
+      return { comments: [], total: 0 }
     }
     return result.value
   })

--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -7,20 +7,20 @@
 	import type { RecipesLikeResponse } from '../../../api/recipes/like/+server.js'
 	import type { RecipesSaveResponse } from '../../../api/recipes/save/+server.js'
 	import type { CollectionsResponse } from '../../../api/collections/+server.js'
-	import type { Comments } from '../../../api/recipes/[id]/comments/+server.js'
+import type { CommentsResponse } from '../../../api/recipes/[id]/comments/+server.js'
 
 	const COMMENTS_PER_PAGE = 10
 
 	let { data } = $props()
-	let comments = $state(data.comments)
-	let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
-	let hasMore = $state(false)
+        let comments = $state(data.comments)
+        let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
+        let hasMore = $state(false)
 
-	$effect(() => {
-		data.comments.then((c) => {
-			hasMore = c.length === COMMENTS_PER_PAGE
-		})
-	})
+        $effect(() => {
+                data.comments.then((c) => {
+                        hasMore = c.comments.length === COMMENTS_PER_PAGE
+                })
+        })
 
 	const handleLike = async () => {
 		await safeFetch<RecipesLikeResponse>()(`/api/recipes/like`, {
@@ -60,14 +60,14 @@
 		}
 	}
 
-	const loadComments = async (pageNum: number) => {
-		const result = await safeFetch<Comments>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
-		if (result.isOk()) {
-			comments = Promise.resolve(result.value)
-			hasMore = result.value.length === COMMENTS_PER_PAGE
-			currentPage = pageNum
-		}
-	}
+        const loadComments = async (pageNum: number) => {
+                const result = await safeFetch<CommentsResponse>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
+                if (result.isOk()) {
+                        comments = Promise.resolve(result.value)
+                        hasMore = result.value.comments.length === COMMENTS_PER_PAGE
+                        currentPage = pageNum
+                }
+        }
 
 	const nextPage = async () => {
 		if (!hasMore) return

--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -7,20 +7,20 @@
 	import type { RecipesLikeResponse } from '../../../api/recipes/like/+server.js'
 	import type { RecipesSaveResponse } from '../../../api/recipes/save/+server.js'
 	import type { CollectionsResponse } from '../../../api/collections/+server.js'
-import type { CommentsResponse } from '../../../api/recipes/[id]/comments/+server.js'
+	import type { CommentsResponse } from '../../../api/recipes/[id]/comments/+server.js'
 
 	const COMMENTS_PER_PAGE = 10
 
 	let { data } = $props()
-        let comments = $state(data.comments)
-        let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
-        let hasMore = $state(false)
+	let comments = $state(data.comments)
+	let currentPage = $state(parseInt(page.url.searchParams.get('page') || '0', 10))
+	let hasMore = $state(false)
 
-        $effect(() => {
-                data.comments.then((c) => {
-                        hasMore = c.comments.length === COMMENTS_PER_PAGE
-                })
-        })
+	$effect(() => {
+		data.comments.then((c) => {
+			hasMore = c.comments.length === COMMENTS_PER_PAGE
+		})
+	})
 
 	const handleLike = async () => {
 		await safeFetch<RecipesLikeResponse>()(`/api/recipes/like`, {
@@ -60,14 +60,16 @@ import type { CommentsResponse } from '../../../api/recipes/[id]/comments/+serve
 		}
 	}
 
-        const loadComments = async (pageNum: number) => {
-                const result = await safeFetch<CommentsResponse>()(`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`)
-                if (result.isOk()) {
-                        comments = Promise.resolve(result.value)
-                        hasMore = result.value.comments.length === COMMENTS_PER_PAGE
-                        currentPage = pageNum
-                }
-        }
+	const loadComments = async (pageNum: number) => {
+		const result = await safeFetch<CommentsResponse>()(
+			`/api/recipes/${(await data.recipe).id}/comments?page=${pageNum}`
+		)
+		if (result.isOk()) {
+			comments = Promise.resolve(result.value)
+			hasMore = result.value.comments.length === COMMENTS_PER_PAGE
+			currentPage = pageNum
+		}
+	}
 
 	const nextPage = async () => {
 		if (!hasMore) return

--- a/src/routes/api/recipes/[id]/comments/+server.ts
+++ b/src/routes/api/recipes/[id]/comments/+server.ts
@@ -1,9 +1,9 @@
 import { error, json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
-import { getComments, addComment } from '$lib/server/db/recipe-comments'
+import { getComments, addComment, getCommentCount } from '$lib/server/db/recipe-comments'
 import * as v from 'valibot'
 
-export type Comments = {
+export type Comment = {
   id: string
   content: string
   imageUrl?: string
@@ -13,7 +13,12 @@ export type Comments = {
     username: string
     avatarUrl?: string
   }
-}[]
+}
+
+export type CommentsResponse = {
+  comments: Comment[]
+  total: number
+}
 
 export const GET: RequestHandler = async ({ params, url }) => {
   const recipeId = params.id
@@ -24,8 +29,9 @@ export const GET: RequestHandler = async ({ params, url }) => {
 
   const limit = parseInt(url.searchParams.get('limit') || '10', 10)
   const page = parseInt(url.searchParams.get('page') || '0', 10)
-  const comments = await getComments(recipeId, limit, page) satisfies Comments
-  return json(comments)
+  const comments = await getComments(recipeId, limit, page)
+  const total = await getCommentCount(recipeId)
+  return json({ comments, total } satisfies CommentsResponse)
 }
 
 const commentSchema = v.object({


### PR DESCRIPTION
## Summary
- display total comment count on recipe page
- show pagination status in comments section
- provide total comment count via API
- support comment count fetching in DB layer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68716d47b078832187e49cd6112130ba