### PR TITLE
Implement Open Graph tags

### DIFF
--- a/src/routes/(pages)/recipe/[id]/+page.svelte
+++ b/src/routes/(pages)/recipe/[id]/+page.svelte
@@ -12,6 +12,8 @@
 
 	let { data } = $props()
 
+	const currentUrl = $derived(page.url.href)
+
 	$effect(() => {
 		data.recipe.then((r) => {
 			if (!r) {
@@ -96,6 +98,21 @@
 
 	const unitSystem = $derived(unitPreferenceStore.unitSystem)
 </script>
+
+<svelte:head>
+	{#await data.recipe then recipe}
+		<title>{recipe.title} - Forkly</title>
+		<meta property="og:type" content="article" />
+		<meta property="og:title" content={recipe.title} />
+		{#if recipe.description}
+			<meta property="og:description" content={recipe.description} />
+		{/if}
+		{#if recipe.imageUrl}
+			<meta property="og:image" content={recipe.imageUrl} />
+		{/if}
+		<meta property="og:url" content={currentUrl} />
+	{/await}
+</svelte:head>
 
 <div class="recipe-page" data-page="recipe">
 	<Recipe

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -72,6 +72,7 @@
 	const slots = initSlots()
 
 	let homepage = $derived(page.url.pathname === '/')
+	const currentUrl = $derived(page.url.href)
 
 	let homepageHeaderTransition = $state(true)
 
@@ -106,6 +107,11 @@
 
 <svelte:head>
 	<title>Forkly - Discover and Share Recipes</title>
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Forkly" />
+	<meta property="og:description" content="Discover and share recipes on Forkly." />
+	<meta property="og:image" content="/favicon.png" />
+	<meta property="og:url" content={currentUrl} />
 </svelte:head>
 
 {@render children()}


### PR DESCRIPTION
## Summary
- add default Open Graph tags in the layout
- generate recipe-specific Open Graph tags using recipe details

## Testing
- `npx prettier -w src/routes/+layout.svelte`
- `npx prettier -w "src/routes/(pages)/recipe/[id]/+page.svelte"`


------
https://chatgpt.com/codex/tasks/task_e_6880d7becc8c83219473270cf9e74b4f